### PR TITLE
Fix: Asset Balance Fetch on Testnet

### DIFF
--- a/packages/vechain-kit/src/config/testnet.ts
+++ b/packages/vechain-kit/src/config/testnet.ts
@@ -25,7 +25,7 @@ const config: AppConfig = {
     veDelegateVotes: '0xeb71148c9B3cd57e228c2152d79f6e78F5F1ef9a',
     veDelegateTokenContractAddress:
         '0xD3f7b82Df5705D34f64C634d2dEf6B1cB3116950',
-    oracleContractAddress: '0x49eC7192BF804Abc289645ca86F1eD01a6C17713',
+    oracleContractAddress: '0xdcCAaBd81B38e0dEEf4c202bC7F1261A4D9192C6',
     accountFactoryAddress: '0x7EABA81B4F3741Ac381af7e025f3B6e0428F05Fb',
     cleanifyCampaignsContractAddress:
         '0x22d19ACBD2cBf6b2B6C546395c26B9Cb448248BF',


### PR DESCRIPTION
# Description

Updated the config to use the correct oracle address on testnet, ensuring accurate asset balance retrieval.

Fixes #59 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code

# Screenshot

## BEFORE
![Screenshot 2025-01-30 at 12 32 02](https://github.com/user-attachments/assets/a2ae4c77-76cb-4c5b-93dc-b3333f3a7964)

## AFTER

![Screenshot 2025-01-30 at 12 32 40](https://github.com/user-attachments/assets/72dfbe20-38ef-42f2-88d8-cc1968269d91)
