### PR TITLE
Fix: App Fetch Compatibility for Older SC Versions

### DIFF
--- a/packages/vechain-kit/src/components/AccountModal/Contents/Ecosystem/ExploreEcosystemContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Ecosystem/ExploreEcosystemContent.tsx
@@ -83,16 +83,20 @@ const DEFAULT_APPS: XAppMetadata[] = [
 
 export const ExploreEcosystemContent = ({ setCurrentContent }: Props) => {
     const { t } = useTranslation();
-    const { darkMode: isDark } = useVeChainKitConfig();
+    const { darkMode: isDark, network } = useVeChainKitConfig();
     const [searchQuery, setSearchQuery] = useState('');
     const { data: currentRoundId } = useCurrentAllocationsRoundId();
     const { data: vbdApps } = useMostVotedAppsInRound(
         currentRoundId ? (parseInt(currentRoundId) - 1).toString() : '1',
     );
 
-    const filteredDapps = vbdApps.filter((dapp) =>
-        dapp.app.name.toLowerCase().includes(searchQuery.toLowerCase()),
-    );
+    // Only show VBD apps if we're on mainnet
+    const isMainnet = network.type === 'main';
+    const filteredDapps = isMainnet
+        ? vbdApps.filter((dapp) =>
+              dapp.app.name.toLowerCase().includes(searchQuery.toLowerCase()),
+          )
+        : [];
 
     const filteredDefaultApps = DEFAULT_APPS.filter((dapp) =>
         dapp.name.toLowerCase().includes(searchQuery.toLowerCase()),

--- a/packages/vechain-kit/src/hooks/api/vebetterdao/xApps/getXApps.ts
+++ b/packages/vechain-kit/src/hooks/api/vebetterdao/xApps/getXApps.ts
@@ -84,7 +84,7 @@ export const getXApps = async (
             }));
         }
     }
-    if (res[1]?.data) {
+    if (res[1]?.data && res[1]?.data !== '0x') {
         const unendorsedAppsDecoded = unendorsedAppsAbi.decode(res[1]?.data)[0];
         if (unendorsedAppsDecoded.length) {
             unendorsedApps = unendorsedAppsDecoded.map((app: any) => ({


### PR DESCRIPTION
# Description

This PR updates the app fetching logic to check response for unendorsed apps which ensure compatibility with older smart contract versions that do not support endorsements.

Fixes #62

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code


# Screen Recording 

## Mainnet (X2EarnApps V3)


https://github.com/user-attachments/assets/5baf571c-760b-4782-b7f8-ee7e695a9b94



## Testnet (X2EarnApps V1)

https://github.com/user-attachments/assets/be101447-7a2b-49b3-a37f-316e3169f802

