### PR TITLE
Feat/login modal refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <h1><code>vechain-kit</code></h1>
     <p>
-        <strong>A all-in-one library for building VeChain applications.</strong>
+        <strong>An all-in-one library for building VeChain applications.</strong>
     </p>
     <p>
         <a href="https://sonarcloud.io/project/overview?id=vechain_vechain-dapp-kit"><img src="https://sonarcloud.io/api/project_badges/measure?project=vechain_vechain-dapp-kit&metric=security_rating&token=69ceb851539382455c3eba073d1690bb58147af5" alt="Security Rating"></a>

--- a/examples/homepage/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/homepage/src/app/providers/VechainKitProviderWrapper.tsx
@@ -88,14 +88,10 @@ export function VechainKitProviderWrapper({ children }: Props) {
                 },
             }}
             loginModalUI={{
-                // preferredLoginMethods: ['google'],
-                variant: 'vechain',
                 logo: appLogo,
                 description:
                     'Choose between social login through VeChain or by connecting your wallet.',
             }}
-            // Leave this empty to remove the ecosystem button
-            privyEcosystemAppIDS={[]}
             darkMode={isDarkMode}
             language={i18n.language}
             network={{

--- a/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
@@ -88,14 +88,10 @@ export function VechainKitProviderWrapper({ children }: Props) {
                 },
             }}
             loginModalUI={{
-                // preferredLoginMethods: ['google'],
-                variant: 'vechain',
                 logo: appLogo,
                 description:
                     'Choose between social login through VeChain or by connecting your wallet.',
             }}
-            // Leave this empty to remove the ecosystem button
-            privyEcosystemAppIDS={[]}
             darkMode={isDarkMode}
             language={i18n.language}
             network={{

--- a/packages/vechain-kit/README.md
+++ b/packages/vechain-kit/README.md
@@ -40,22 +40,15 @@ yarn add @tanstack/react-query@"^5.64.2" @chakra-ui/react@"^2.8.2" @vechain/dapp
 ```typescript
 'use client';
 
-
-import VeChainKitProvider from '@vechain/vechain-kit'
-​
+import VeChainKitProvider from '@vechain/vechain-kit';
 export function VeChainKitProviderWrapper({ children }: Props) {
     return (
-         <VechainKitProvider
-            // Mandatory
+        <VechainKitProvider
             feeDelegation={{
-                delegatorUrl: process.env.NEXT_PUBLIC_DELEGATOR_URL!
+                delegatorUrl: process.env.NEXT_PUBLIC_DELEGATOR_URL!,
             }}
             dappKit={{
                 allowedWallets: ['veworld', 'sync2'],
-            }}
-            privyEcosystemApps=[] // remove for using default ones
-            loginModalUI={{
-                variant: 'vechain-wallet-ecosystem',
             }}
             darkMode={true}
             language="en"
@@ -83,6 +76,50 @@ interface Props {
     children: React.ReactNode;
 }
 ```
+
+### Available Login Methods
+
+The modal supports several authentication methods:
+
+-   Social Login - Email and Google authentication through Privy (only available for self hosted Privy)
+-   VeChain Login - Direct VeChain wallet authentication
+-   Passkey - Biometric/device-based authentication (only available for self hosted Privy)
+-   DappKit - Connection through VeWorld or other VeChain wallets
+-   Ecosystem - Cross-app authentication within the VeChain ecosystem
+-   More Options - Additional Privy-supported login methods (only available for self hosted Privy)
+
+#### Configuration
+
+The modal implements a dynamic grid layout system that can be customized through the `loginMethods` configuration.
+
+The modal can be configured through the `VeChainKitProvider` props.
+
+```typescript
+<VeChainKitProvider
+    loginModalUI={{
+        logo: '/your-logo.png',
+        description: 'Custom login description',
+    }}
+    loginMethods={[
+        { method: 'vechain', gridColumn: 4 },
+        { method: 'email', gridColumn: 2 },
+        { method: 'passkey', gridColumn: 2 },
+    ]}
+>
+    {children}
+</VeChainKitProvider>
+```
+
+#### Ecosystem button
+
+The ways to show the ecosystem login button are:
+
+1. You define "ecosystem" in the loginMethods in the config
+2. You do not define the loginMethods in the config, so we default to showing the ecosystem login button
+
+To not show the ecosystem login button, you must explicitly define the loginMethods array in the config and not include ecosystem in the options.
+
+By default we have a list of default apps that will be shown as ecosystem login options. If you want to customize this list you can pass the `allowedApps` array prop. You can find the app ids in the [Ecosystem](https://dashboard.privy.io/) tab in the Privy dashboard.
 
 ### Setup Fee Delegation (mandatory)
 

--- a/packages/vechain-kit/src/components/ConnectModal/Components/EcosystemButton.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/EcosystemButton.tsx
@@ -6,28 +6,32 @@ import { PrivyAppInfo } from '@/types';
 
 type Props = {
     isDark: boolean;
-    privySocialLoginEnabled: boolean;
     appsInfo: PrivyAppInfo[];
     isLoading: boolean;
+    gridColumn?: number;
 };
 
 export const EcosystemButton = ({
     isDark,
-    privySocialLoginEnabled,
     appsInfo,
     isLoading,
+    gridColumn,
 }: Props) => {
     const { t } = useTranslation();
     const ecosystemModal = useDisclosure();
 
     return (
         <>
-            <GridItem colSpan={privySocialLoginEnabled ? 1 : 2} w={'full'}>
+            <GridItem colSpan={gridColumn} w={'full'}>
                 <ConnectionButton
                     isDark={isDark}
                     onClick={ecosystemModal.onOpen}
                     icon={IoPlanet}
-                    text={!privySocialLoginEnabled ? t('Ecosystem') : undefined}
+                    text={
+                        gridColumn && gridColumn >= 2
+                            ? t('Ecosystem')
+                            : undefined
+                    }
                 />
             </GridItem>
 

--- a/packages/vechain-kit/src/components/ConnectModal/Components/PasskeyLoginButton.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/PasskeyLoginButton.tsx
@@ -10,7 +10,7 @@ type Props = {
     gridColumn?: number;
 };
 
-export const PasskeyLoginButton = ({ isDark, gridColumn = 1 }: Props) => {
+export const PasskeyLoginButton = ({ isDark, gridColumn }: Props) => {
     const { t } = useTranslation();
     const { loginWithPasskey } = useLoginWithPasskey();
     const [loginError, setLoginError] = useState<string>();
@@ -39,6 +39,9 @@ export const PasskeyLoginButton = ({ isDark, gridColumn = 1 }: Props) => {
                     isDark={isDark}
                     onClick={handleLoginWithPasskey}
                     icon={IoIosFingerPrint}
+                    text={
+                        gridColumn && gridColumn >= 2 ? t('Passkey') : undefined
+                    }
                 />
             </GridItem>
 

--- a/packages/vechain-kit/src/components/ConnectModal/Components/PrivyButton.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/PrivyButton.tsx
@@ -6,14 +6,10 @@ import { useTranslation } from 'react-i18next';
 type Props = {
     isDark: boolean;
     onViewMoreLogin: () => void;
-    gridColumn: number;
+    gridColumn?: number;
 };
 
-export const PrivyButton = ({
-    isDark,
-    onViewMoreLogin,
-    gridColumn = 1,
-}: Props) => {
+export const PrivyButton = ({ isDark, onViewMoreLogin, gridColumn }: Props) => {
     const { t } = useTranslation();
     return (
         <GridItem colSpan={gridColumn} w={'full'}>
@@ -21,7 +17,7 @@ export const PrivyButton = ({
                 isDark={isDark}
                 onClick={onViewMoreLogin}
                 icon={CiCircleMore}
-                text={gridColumn >= 2 ? t('More') : undefined}
+                text={gridColumn && gridColumn >= 2 ? t('More') : undefined}
             />
         </GridItem>
     );

--- a/packages/vechain-kit/src/components/ConnectModal/Components/SocialLoginButtons.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/SocialLoginButtons.tsx
@@ -8,23 +8,32 @@ import { useLoginWithOAuth } from '@/hooks';
 
 type Props = {
     isDark: boolean;
-    loginModalUI: VechainKitProviderProps['loginModalUI'];
+    loginMethods?: VechainKitProviderProps['loginMethods'];
+    gridColumn?: number;
 };
 
-export const SocialLoginButtons = ({ isDark, loginModalUI }: Props) => {
+export const SocialLoginButtons = ({
+    isDark,
+    loginMethods,
+    gridColumn,
+}: Props) => {
     const { t } = useTranslation();
     const { initOAuth } = useLoginWithOAuth();
 
+    const selfHostedPrivyLoginMethods = loginMethods?.filter(
+        (method) => method.method === 'email' || method.method === 'google',
+    );
+
     return (
-        <>
-            {loginModalUI?.preferredLoginMethods?.map((method, index) => (
-                <React.Fragment key={method}>
-                    {method === 'email' && (
+        <GridItem colSpan={gridColumn} w={'full'}>
+            {selfHostedPrivyLoginMethods?.map((loginMethod, index) => (
+                <React.Fragment key={loginMethod.method}>
+                    {loginMethod.method === 'email' && (
                         <GridItem colSpan={4} w={'full'}>
                             <EmailLoginButton />
                         </GridItem>
                     )}
-                    {method === 'google' && (
+                    {loginMethod.method === 'google' && (
                         <GridItem colSpan={4} w={'full'}>
                             <ConnectionButton
                                 isDark={isDark}
@@ -40,8 +49,7 @@ export const SocialLoginButtons = ({ isDark, loginModalUI }: Props) => {
                     )}
 
                     {index !==
-                        (loginModalUI?.preferredLoginMethods?.length ?? 0) -
-                            1 && (
+                        (selfHostedPrivyLoginMethods?.length ?? 0) - 1 && (
                         <GridItem colSpan={4} w={'full'}>
                             <HStack>
                                 <Divider />
@@ -52,6 +60,6 @@ export const SocialLoginButtons = ({ isDark, loginModalUI }: Props) => {
                     )}
                 </React.Fragment>
             ))}
-        </>
+        </GridItem>
     );
 };

--- a/packages/vechain-kit/src/components/ConnectModal/ConnectModal.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/ConnectModal.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { MainContent } from './Contents/MainContent';
 import { BaseModal } from '@/components/common';
 import { FAQContent } from '../AccountModal';
-import { useVeChainKitConfig } from '@/providers';
 
 type Props = {
     isOpen: boolean;
@@ -14,7 +13,6 @@ type Props = {
 export type ConnectModalContentsTypes = 'main' | 'email-verification' | 'faq';
 
 export const ConnectModal = ({ isOpen, onClose }: Props) => {
-    const { loginModalUI } = useVeChainKitConfig();
     const [currentContent, setCurrentContent] =
         useState<ConnectModalContentsTypes>('main');
 
@@ -31,7 +29,6 @@ export const ConnectModal = ({ isOpen, onClose }: Props) => {
                     <MainContent
                         setCurrentContent={setCurrentContent}
                         onClose={onClose}
-                        variant={loginModalUI?.variant}
                     />
                 );
             case 'faq':

--- a/packages/vechain-kit/src/hooks/modals/index.ts
+++ b/packages/vechain-kit/src/hooks/modals/index.ts
@@ -11,3 +11,4 @@ export * from './useNotificationsModal';
 export * from './useFAQModal';
 export * from './useAccountCustomizationModal';
 export * from './useReceiveModal';
+export * from './useLoginModalContent';

--- a/packages/vechain-kit/src/hooks/modals/useLoginModalContent.ts
+++ b/packages/vechain-kit/src/hooks/modals/useLoginModalContent.ts
@@ -1,0 +1,84 @@
+import { useVeChainKitConfig } from '@/providers';
+import { VECHAIN_PRIVY_APP_ID } from '@/utils';
+import { useMemo } from 'react';
+
+type LoginModalContentConfig = {
+    showSocialLogin: boolean;
+    showPasskey: boolean;
+    showVeChainLogin: boolean;
+    showDappKit: boolean;
+    showEcosystem: boolean;
+    showMoreLogin: boolean;
+    isOfficialVeChainApp: boolean;
+};
+
+export const useLoginModalContent = (): LoginModalContentConfig => {
+    const { privy, loginMethods } = useVeChainKitConfig();
+
+    const isVeChainApp = privy?.appId === VECHAIN_PRIVY_APP_ID;
+    // The ways to show the ecosystem login button are:
+    // 1. The user has defined the loginMethods in the config
+    // 2. The user has not defined the loginMethods in the config so we default to showing the ecosystem login button
+    //
+    // To not show the ecosystem login button, the user must explicitly define the loginMethods in the config and not include the ecosystem login button
+    const showEcosystemLogin = useMemo(() => {
+        // by default we always show the ecosystem login button
+        if (!loginMethods) return true;
+
+        // if loginMethods is defined by the user BUT there is no ecosystem then we return false
+        if (
+            loginMethods.length > 0 &&
+            !loginMethods?.find((method) => method.method === 'ecosystem')
+        ) {
+            return false;
+        }
+
+        return true;
+    }, [loginMethods]);
+
+    if (!privy) {
+        // External apps (no self hosted privy)
+        return {
+            showSocialLogin: false,
+            showPasskey: false,
+            showVeChainLogin: true,
+            showDappKit: true,
+            showEcosystem: showEcosystemLogin,
+            showMoreLogin: false,
+            isOfficialVeChainApp: false,
+        };
+    }
+
+    // Will be used by VeBetterDAO or any other official VeChain app
+    if (isVeChainApp) {
+        // VeChain app (using self hosted privy)
+        return {
+            showSocialLogin: false,
+            showPasskey: false,
+            showVeChainLogin: true,
+            showDappKit: true,
+            showEcosystem: showEcosystemLogin,
+            showMoreLogin: false,
+            isOfficialVeChainApp: true,
+        };
+    }
+
+    // Self hosted privy app
+
+    // Check if we need to show the "more login options" button
+    const showMoreLogin = useMemo(() => {
+        if (!loginMethods) return true;
+
+        return loginMethods.some((method) => method.method === 'more');
+    }, [loginMethods]);
+
+    return {
+        showSocialLogin: true,
+        showPasskey: true,
+        showVeChainLogin: true,
+        showDappKit: true,
+        showEcosystem: showEcosystemLogin,
+        showMoreLogin: showMoreLogin,
+        isOfficialVeChainApp: false,
+    };
+};


### PR DESCRIPTION
# Description

Refactored the login modal to support an easier customization of the connection types and buttons to show.

For the login there are 3 scenarios:
1) vebetterdao / vechainKitHomepage -> custom login with vechain button (using self hosted privy of vechain)
it should show: login with vechain button + connect wallet button + ecosystem button (optional)
 what we do:
 - check if the app id and client id === vechain then we show "login with vechain button" (no crossapp)
                                                otherwise we show "login with vechain button (crossapp)"

2) external apps (no self hosted privy) => we are here if privy prop is not set
 it should show: login with vechain button (crossapp) + connect wallet button + ecosystem button (optional)

3) self hosted privy app => we are here if privy prop is set
it should show: login with google (or/and email) button (optional) + login with vechain button (crossapp) + connect wallet button
+ ecosystem button (optional) + passkey button (optional) + view more login button (optional?)

With this PR we **deprecate** the following parameters when using the VeChainKitProvider:
- privyEcosystemAppIDS
- variant (in loginModalUI)

Now instead of choosing a variant we can use a new prop named `loginMethods` where the dev can decide what to show, and it has the following type:

```
type LoginMethodOrder = {
    method:
        | 'email'
        | 'google'
        | 'passkey'
        | 'vechain'
        | 'dappkit'
        | 'ecosystem'
        | 'more';
    gridColumn?: number;
    allowedApps?: string[]; // Only used by ecosystem method, if it's not provided, it will use default apps
};
```

# Updated packages (if any):

[x ] next-template
[x ] homepage
[x ] vechain-kit
