### PR TITLE
feat: use separate provider for exported modals + fix when opening in veworld

### DIFF
--- a/packages/vechain-kit/src/components/AccountModal/Contents/PrivyLinkedAccounts/PrivyLinkedAccounts.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/PrivyLinkedAccounts/PrivyLinkedAccounts.tsx
@@ -172,7 +172,14 @@ export const PrivyLinkedAccounts = ({ onBack }: PrivyLinkedAccountsProps) => {
     };
 
     const canUnlink = () => {
-        return user?.linkedAccounts && user?.linkedAccounts?.length > 1;
+        // the embedded wallet is always in this list, so we need to exclude it
+        const linkedAccountsExcludingWallet = user?.linkedAccounts?.filter(
+            (account) => account.type !== 'wallet',
+        );
+        return (
+            linkedAccountsExcludingWallet &&
+            linkedAccountsExcludingWallet?.length > 1
+        );
     };
 
     const handleUnlink = async (account: any) => {
@@ -180,52 +187,56 @@ export const PrivyLinkedAccounts = ({ onBack }: PrivyLinkedAccountsProps) => {
 
         setIsLoadingUnlink(true);
 
-        switch (account.type) {
-            case 'google_oauth':
-                await unlinkGoogle(account.subject);
-                break;
-            case 'email':
-                await unlinkEmail(account.address);
-                break;
-            case 'passkey':
-                await unlinkPasskey(account.subject);
-                break;
-            case 'phone':
-                await unlinkPhone(account.number);
-                break;
-            case 'spotify_oauth':
-                await unlinkSpotify(account.subject);
-                break;
-            case 'apple_oauth':
-                await unlinkApple(account.subject);
-                break;
-            case 'instagram_oauth':
-                await unlinkInstagram(account.subject);
-                break;
-            case 'tiktok_oauth':
-                await unlinkTiktok(account.subject);
-                break;
-            case 'github_oauth':
-                await unlinkGithub(account.subject);
-                break;
-            case 'linkedin_oauth':
-                await unlinkLinkedIn(account.subject);
-                break;
-            case 'telegram':
-                await unlinkTelegram(account.subject);
-                break;
-            case 'farcaster':
-                await unlinkFarcaster(account.subject);
-                break;
-            case 'discord_oauth':
-                await unlinkDiscord(account.subject);
-                break;
-            default:
-                break;
+        try {
+            switch (account.type) {
+                case 'google_oauth':
+                    await unlinkGoogle(account.subject);
+                    break;
+                case 'email':
+                    await unlinkEmail(account.address);
+                    break;
+                case 'passkey':
+                    await unlinkPasskey(account.subject);
+                    break;
+                case 'phone':
+                    await unlinkPhone(account.number);
+                    break;
+                case 'spotify_oauth':
+                    await unlinkSpotify(account.subject);
+                    break;
+                case 'apple_oauth':
+                    await unlinkApple(account.subject);
+                    break;
+                case 'instagram_oauth':
+                    await unlinkInstagram(account.subject);
+                    break;
+                case 'tiktok_oauth':
+                    await unlinkTiktok(account.subject);
+                    break;
+                case 'github_oauth':
+                    await unlinkGithub(account.subject);
+                    break;
+                case 'linkedin_oauth':
+                    await unlinkLinkedIn(account.subject);
+                    break;
+                case 'telegram':
+                    await unlinkTelegram(account.subject);
+                    break;
+                case 'farcaster':
+                    await unlinkFarcaster(account.subject);
+                    break;
+                case 'discord_oauth':
+                    await unlinkDiscord(account.subject);
+                    break;
+                default:
+                    break;
+            }
+        } catch (error) {
+            console.error(error);
+        } finally {
+            setIsLoadingUnlink(false);
+            setUnlinkingAccount(null);
         }
-
-        setIsLoadingUnlink(false);
-        setUnlinkingAccount(null);
     };
 
     const getAccountDescription = (account: any) => {

--- a/packages/vechain-kit/src/components/WalletButton/WalletButton.tsx
+++ b/packages/vechain-kit/src/components/WalletButton/WalletButton.tsx
@@ -1,8 +1,6 @@
 import { Button, ButtonProps, useDisclosure } from '@chakra-ui/react';
 import { useWallet } from '@/hooks';
 import { useWallet as useDappKitWallet } from '@vechain/dapp-kit-react';
-import { usePrivy } from '@privy-io/react-auth';
-import { useEffect } from 'react';
 import { ConnectModal, AccountModal } from '@/components';
 import { ConnectedWallet } from './ConnectedWallet';
 import { WalletDisplayVariant } from './types';
@@ -25,7 +23,6 @@ export const WalletButton = ({
 
     const { connection, account } = useWallet();
     const { setSource, connect } = useDappKitWallet();
-    const { authenticated, user, createWallet } = usePrivy();
 
     const connectModal = useDisclosure();
     const accountModal = useDisclosure();
@@ -38,22 +35,6 @@ export const WalletButton = ({
             connectModal.onOpen();
         }
     };
-
-    useEffect(() => {
-        const embeddedWallet = user?.wallet?.address;
-
-        const asyncCreateWallet = async () => {
-            try {
-                await createWallet();
-            } catch (error) {
-                console.error(error);
-            }
-        };
-
-        if (authenticated && !connection.isLoading && !embeddedWallet) {
-            asyncCreateWallet();
-        }
-    }, [authenticated, connection, user]);
 
     return (
         <VechainKitThemeProvider darkMode={darkMode}>

--- a/packages/vechain-kit/src/hooks/modals/useAccessAndSecurityModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useAccessAndSecurityModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useAccessAndSecurityModal = () => {
@@ -7,7 +7,7 @@ export const useAccessAndSecurityModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('access-and-security');

--- a/packages/vechain-kit/src/hooks/modals/useAccountCustomizationModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useAccountCustomizationModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useAccountCustomizationModal = () => {
@@ -7,7 +7,7 @@ export const useAccountCustomizationModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('account-customization');

--- a/packages/vechain-kit/src/hooks/modals/useAccountModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useAccountModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useAccountModal = () => {
@@ -6,7 +6,7 @@ export const useAccountModal = () => {
         openAccountModal: open,
         closeAccountModal: close,
         isAccountModalOpen: isOpen,
-    } = useVeChainKitConfig();
+    } = useModal();
     return { open, close, isOpen };
 };
 

--- a/packages/vechain-kit/src/hooks/modals/useChooseNameModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useChooseNameModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useChooseNameModal = () => {
@@ -7,7 +7,7 @@ export const useChooseNameModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('choose-name');

--- a/packages/vechain-kit/src/hooks/modals/useConnectModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useConnectModal = () => {
@@ -6,7 +6,7 @@ export const useConnectModal = () => {
         openConnectModal: open,
         closeConnectModal: close,
         isConnectModalOpen: isOpen,
-    } = useVeChainKitConfig();
+    } = useModal();
     return { open, close, isOpen };
 };
 

--- a/packages/vechain-kit/src/hooks/modals/useExploreEcosystemModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useExploreEcosystemModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useExploreEcosystemModal = () => {
@@ -7,7 +7,7 @@ export const useExploreEcosystemModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('ecosystem');

--- a/packages/vechain-kit/src/hooks/modals/useFAQModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useFAQModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useFAQModal = () => {
@@ -7,7 +7,7 @@ export const useFAQModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('faq');

--- a/packages/vechain-kit/src/hooks/modals/useNotificationsModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useNotificationsModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useNotificationsModal = () => {
@@ -7,7 +7,7 @@ export const useNotificationsModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('notifications');

--- a/packages/vechain-kit/src/hooks/modals/useReceiveModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useReceiveModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useReceiveModal = () => {
@@ -7,7 +7,7 @@ export const useReceiveModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent('receive-token');

--- a/packages/vechain-kit/src/hooks/modals/useSendTokenModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useSendTokenModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useSendTokenModal = () => {
@@ -7,7 +7,7 @@ export const useSendTokenModal = () => {
         closeAccountModal,
         isAccountModalOpen,
         setAccountModalContent,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         setAccountModalContent({

--- a/packages/vechain-kit/src/hooks/modals/useTransactionModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useTransactionModal.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useTransactionModal = () => {
@@ -6,7 +6,7 @@ export const useTransactionModal = () => {
         openTransactionModal: open,
         closeTransactionModal: close,
         isTransactionModalOpen: isOpen,
-    } = useVeChainKitConfig();
+    } = useModal();
     return { open, close, isOpen };
 };
 

--- a/packages/vechain-kit/src/hooks/modals/useTransactionToast.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useTransactionToast.tsx
@@ -1,4 +1,4 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useTransactionToast = () => {
@@ -6,7 +6,7 @@ export const useTransactionToast = () => {
         openTransactionToast: open,
         closeTransactionToast: close,
         isTransactionToastOpen: isOpen,
-    } = useVeChainKitConfig();
+    } = useModal();
     return { open, close, isOpen };
 };
 

--- a/packages/vechain-kit/src/hooks/modals/useWalletModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useWalletModal.tsx
@@ -1,5 +1,5 @@
 import { useWallet } from '@/hooks';
-import { useVeChainKitConfig } from '@/providers';
+import { useModal } from '@/providers/ModalProvider';
 import { ReactNode } from 'react';
 
 export const useWalletModal = () => {
@@ -11,7 +11,7 @@ export const useWalletModal = () => {
         openAccountModal,
         closeAccountModal,
         isAccountModalOpen,
-    } = useVeChainKitConfig();
+    } = useModal();
 
     const open = () => {
         if (connection.isConnected) {

--- a/packages/vechain-kit/src/providers/ModalProvider.tsx
+++ b/packages/vechain-kit/src/providers/ModalProvider.tsx
@@ -1,0 +1,124 @@
+import {
+    createContext,
+    ReactNode,
+    useCallback,
+    useContext,
+    useState,
+} from 'react';
+import {
+    AccountModal,
+    AccountModalContentTypes,
+    ConnectModal,
+} from '../components';
+import { useDappKitWallet } from '@/hooks';
+
+type ModalContextType = {
+    // Connect Modal
+    openConnectModal: () => void;
+    closeConnectModal: () => void;
+    isConnectModalOpen: boolean;
+    // Account Modal
+    openAccountModal: () => void;
+    closeAccountModal: () => void;
+    isAccountModalOpen: boolean;
+    setAccountModalContent: React.Dispatch<
+        React.SetStateAction<AccountModalContentTypes>
+    >;
+    // Transaction Modal
+    openTransactionModal: () => void;
+    closeTransactionModal: () => void;
+    isTransactionModalOpen: boolean;
+    // Transaction Toast
+    openTransactionToast: () => void;
+    closeTransactionToast: () => void;
+    isTransactionToastOpen: boolean;
+};
+
+const ModalContext = createContext<ModalContextType | null>(null);
+
+export const useModal = () => {
+    const context = useContext(ModalContext);
+    if (!context) {
+        throw new Error('useModal must be used within ModalProvider');
+    }
+    return context;
+};
+
+export const ModalProvider = ({ children }: { children: ReactNode }) => {
+    const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
+    const { setSource, connect } = useDappKitWallet();
+    const openConnectModal = useCallback(() => {
+        // If the user is in the veworld app, connect to the wallet
+        if (window.vechain && !window.vechain.isInAppBrowser) {
+            setSource('veworld');
+            connect();
+        } else {
+            setIsConnectModalOpen(true);
+        }
+    }, []);
+    const closeConnectModal = useCallback(
+        () => setIsConnectModalOpen(false),
+        [],
+    );
+
+    const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
+    const openAccountModal = useCallback(() => setIsAccountModalOpen(true), []);
+    const closeAccountModal = useCallback(
+        () => setIsAccountModalOpen(false),
+        [],
+    );
+
+    const [isTransactionModalOpen, setIsTransactionModalOpen] = useState(false);
+    const openTransactionModal = useCallback(
+        () => setIsTransactionModalOpen(true),
+        [],
+    );
+    const closeTransactionModal = useCallback(
+        () => setIsTransactionModalOpen(false),
+        [],
+    );
+
+    const [isTransactionToastOpen, setIsTransactionToastOpen] = useState(false);
+    const openTransactionToast = useCallback(
+        () => setIsTransactionToastOpen(true),
+        [],
+    );
+    const closeTransactionToast = useCallback(
+        () => setIsTransactionToastOpen(false),
+        [],
+    );
+
+    const [accountModalContent, setAccountModalContent] =
+        useState<AccountModalContentTypes>('main');
+
+    return (
+        <ModalContext.Provider
+            value={{
+                openConnectModal,
+                closeConnectModal,
+                isConnectModalOpen,
+                openAccountModal,
+                closeAccountModal,
+                isAccountModalOpen,
+                setAccountModalContent,
+                openTransactionModal,
+                closeTransactionModal,
+                isTransactionModalOpen,
+                openTransactionToast,
+                closeTransactionToast,
+                isTransactionToastOpen,
+            }}
+        >
+            {children}
+            <ConnectModal
+                isOpen={isConnectModalOpen}
+                onClose={closeConnectModal}
+            />
+            <AccountModal
+                isOpen={isAccountModalOpen}
+                onClose={closeAccountModal}
+                initialContent={accountModalContent}
+            />
+        </ModalContext.Provider>
+    );
+};

--- a/packages/vechain-kit/src/providers/ModalProvider.tsx
+++ b/packages/vechain-kit/src/providers/ModalProvider.tsx
@@ -49,7 +49,7 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
     const { setSource, connect } = useDappKitWallet();
     const openConnectModal = useCallback(() => {
         // If the user is in the veworld app, connect to the wallet
-        if (window.vechain && !window.vechain.isInAppBrowser) {
+        if (window.vechain && window.vechain.isInAppBrowser) {
             setSource('veworld');
             connect();
         } else {

--- a/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
+++ b/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
@@ -2,8 +2,6 @@ import {
     createContext,
     ReactNode,
     useContext,
-    useState,
-    useCallback,
     useEffect,
     useMemo,
 } from 'react';
@@ -12,11 +10,6 @@ import { DAppKitProvider } from '@vechain/dapp-kit-react';
 import { PrivyWalletProvider } from './PrivyWalletProvider';
 import { PrivyCrossAppProvider } from './PrivyCrossAppProvider';
 import { PrivyLoginMethod } from '@/types';
-import {
-    ConnectModal,
-    AccountModal,
-    AccountModalContentTypes,
-} from '../components';
 import { EnsureQueryClient } from './EnsureQueryClient';
 import {
     type LogLevel,
@@ -33,6 +26,7 @@ import { getConfig } from '@/config';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import i18n from '../../i18n';
 import { initializeI18n } from '@/utils/i18n';
+import { ModalProvider } from './ModalProvider';
 
 const DEFAULT_PRIVY_ECOSYSTEM_APP_IDS = [
     'clz41gcg00e4ay75dmq3uzzgr', //cleanify
@@ -113,25 +107,6 @@ type VeChainKitConfig = {
     i18n?: VechainKitProviderProps['i18n'];
     language?: VechainKitProviderProps['language'];
     network: VechainKitProviderProps['network'];
-    // Connect Modal
-    openConnectModal: () => void;
-    closeConnectModal: () => void;
-    isConnectModalOpen: boolean;
-    // Account Modal
-    openAccountModal: () => void;
-    closeAccountModal: () => void;
-    isAccountModalOpen: boolean;
-    setAccountModalContent: React.Dispatch<
-        React.SetStateAction<AccountModalContentTypes>
-    >;
-    // Transaction Modal
-    openTransactionModal: () => void;
-    closeTransactionModal: () => void;
-    isTransactionModalOpen: boolean;
-    // Transaction Toast
-    openTransactionToast: () => void;
-    closeTransactionToast: () => void;
-    isTransactionToastOpen: boolean;
 };
 
 /**
@@ -227,43 +202,6 @@ export const VeChainKitProvider = (
     // Remove the validateLoginMethods call since it's now handled in validateConfig
     const validatedLoginMethods = loginMethods;
 
-    const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
-    const openConnectModal = useCallback(() => setIsConnectModalOpen(true), []);
-    const closeConnectModal = useCallback(
-        () => setIsConnectModalOpen(false),
-        [],
-    );
-
-    const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
-    const openAccountModal = useCallback(() => setIsAccountModalOpen(true), []);
-    const closeAccountModal = useCallback(
-        () => setIsAccountModalOpen(false),
-        [],
-    );
-
-    const [isTransactionModalOpen, setIsTransactionModalOpen] = useState(false);
-    const openTransactionModal = useCallback(
-        () => setIsTransactionModalOpen(true),
-        [],
-    );
-    const closeTransactionModal = useCallback(
-        () => setIsTransactionModalOpen(false),
-        [],
-    );
-
-    const [isTransactionToastOpen, setIsTransactionToastOpen] = useState(false);
-    const openTransactionToast = useCallback(
-        () => setIsTransactionToastOpen(true),
-        [],
-    );
-    const closeTransactionToast = useCallback(
-        () => setIsTransactionToastOpen(false),
-        [],
-    );
-
-    const [accountModalContent, setAccountModalContent] =
-        useState<AccountModalContentTypes>('main');
-
     const allowedEcosystemApps = useMemo(() => {
         const userEcosystemMethods = validatedLoginMethods?.find(
             (method) => method.method === 'ecosystem',
@@ -322,19 +260,6 @@ export const VeChainKitProvider = (
                         i18n: i18nConfig,
                         language,
                         network,
-                        openConnectModal,
-                        closeConnectModal,
-                        isConnectModalOpen,
-                        openAccountModal,
-                        closeAccountModal,
-                        isAccountModalOpen,
-                        setAccountModalContent,
-                        openTransactionModal,
-                        closeTransactionModal,
-                        isTransactionModalOpen,
-                        openTransactionToast,
-                        closeTransactionToast,
-                        isTransactionToastOpen,
                     }}
                 >
                     <PrivyProvider
@@ -412,16 +337,7 @@ export const VeChainKitProvider = (
                                     feeDelegation.delegateAllTransactions
                                 }
                             >
-                                {children}
-                                <ConnectModal
-                                    isOpen={isConnectModalOpen}
-                                    onClose={closeConnectModal}
-                                />
-                                <AccountModal
-                                    isOpen={isAccountModalOpen}
-                                    onClose={closeAccountModal}
-                                    initialContent={accountModalContent}
-                                />
+                                <ModalProvider>{children}</ModalProvider>
                             </PrivyWalletProvider>
                         </DAppKitProvider>
                     </PrivyProvider>


### PR DESCRIPTION
# Description

When using the `useConnectModal()` we now check if it is in in app browser (veworld) then we directly ask veworld to connect instead of showing login choices.

To accomplish this I also moved all the exported modals in a separate provider.

# Updated packages (if any):

[ ] next-template
[ ] homepage
[ x ] vechain-kit
