### PR TITLE
add NEXT_PUBLIC_NETWORK_TYPE to gh workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -30,6 +30,7 @@ jobs:
             NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
             NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
             NEXT_PUBLIC_DELEGATOR_URL: ${{ secrets.NEXT_PUBLIC_DELEGATOR_URL }}
+            NEXT_PUBLIC_NETWORK_TYPE: 'main'
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Fix GH workflow -- add missing env variable

Fixes # (issue)

# Updated packages (if any):

[ ] next-template
[ ] homepage
[ ] vechain-kit
