### PR TITLE
Add Translate step into prepare script

### DIFF
--- a/scripts/prepare-packages.ts
+++ b/scripts/prepare-packages.ts
@@ -50,6 +50,11 @@ const preparePackages = async () => {
     await exec('yarn install:all');
     console.log('       - ✅  Built!');
 
+    console.log(' Translate:');
+    console.log('       - 🌍 Run translations...');
+    await exec('cd packages/vechain-kit && yarn translate && cd -');
+    console.log('       - ✅  Translated!');
+
     console.log(' Test:');
     console.log('       - 🧪 Testing packages...');
     await exec('yarn test');


### PR DESCRIPTION
# Description

This pull request introduces a new translation step in the `prepare-packages.ts` script to ensure that translations are being run before pushing to release branch

Issue: https://github.com/vechain/vechain-kit/issues/87

# Updated packages (if any):

- [ ] next-template
- [ ] homepage
- [ ] vechain-kit
- [x] scripts
