### PR TITLE
fix/rollback x-project-id

### DIFF
--- a/packages/vechain-kit/src/hooks/api/ipfs/useIpfsImage.ts
+++ b/packages/vechain-kit/src/hooks/api/ipfs/useIpfsImage.ts
@@ -23,11 +23,7 @@ export const getIpfsImage = async (
 ): Promise<IpfsImage> => {
     if (!uri) throw new Error('IPFS URI is required');
 
-    const response = await fetch(convertUriToUrl(uri, networkType) ?? '', {
-        headers: {
-            'x-roject-id': 'vechain-kit',
-        },
-    });
+    const response = await fetch(convertUriToUrl(uri, networkType) ?? '');
 
     if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/packages/vechain-kit/src/hooks/api/ipfs/useIpfsImage.ts
+++ b/packages/vechain-kit/src/hooks/api/ipfs/useIpfsImage.ts
@@ -25,7 +25,7 @@ export const getIpfsImage = async (
 
     const response = await fetch(convertUriToUrl(uri, networkType) ?? '', {
         headers: {
-            'X-Project-Id': 'vechain-kit',
+            'x-roject-id': 'vechain-kit',
         },
     });
 

--- a/packages/vechain-kit/src/hooks/api/ipfs/useIpfsMetadata.ts
+++ b/packages/vechain-kit/src/hooks/api/ipfs/useIpfsMetadata.ts
@@ -22,7 +22,7 @@ export const getIpfsMetadata = async <T>(
 
     const response = await fetch(newUri, {
         headers: {
-            'X-Project-Id': 'vechain-kit',
+            'x-project-id': 'vechain-kit',
         },
     });
     const data = await response.text();

--- a/packages/vechain-kit/src/hooks/api/ipfs/useIpfsMetadata.ts
+++ b/packages/vechain-kit/src/hooks/api/ipfs/useIpfsMetadata.ts
@@ -20,11 +20,7 @@ export const getIpfsMetadata = async <T>(
     const newUri = convertUriToUrl(uri, networkType);
     if (!newUri) throw new Error('Invalid URI');
 
-    const response = await fetch(newUri, {
-        headers: {
-            'x-project-id': 'vechain-kit',
-        },
-    });
+    const response = await fetch(newUri);
     const data = await response.text();
 
     if (parseJson) return JSON.parse(data);

--- a/packages/vechain-kit/src/utils/ipfs.ts
+++ b/packages/vechain-kit/src/utils/ipfs.ts
@@ -46,7 +46,7 @@ export async function uploadBlobToIPFS(
             {
                 method: 'POST',
                 headers: {
-                    'X-Project-Id': 'vechain-kit',
+                    'x-project-id': 'vechain-kit',
                 },
                 body: form,
             },

--- a/packages/vechain-kit/src/utils/ipfs.ts
+++ b/packages/vechain-kit/src/utils/ipfs.ts
@@ -45,9 +45,6 @@ export async function uploadBlobToIPFS(
             getConfig(networkType).ipfsPinningService,
             {
                 method: 'POST',
-                headers: {
-                    'x-project-id': 'vechain-kit',
-                },
                 body: form,
             },
         );


### PR DESCRIPTION
# Description

After I added this header api calls fails due to a cors error, saying: 

`Access to fetch at 'https://api.gateway-proxy.vechain.org/ipfs/bafybeif4d3uaienxhxslvpnwxwpewvrvs3egv7rvci3jet5o5v6ssibljm/media/logo.jpeg' from origin 'https://vechain-kit.vechain.org' has been blocked by CORS policy: Request header field x-project-id is not allowed by Access-Control-Allow-Headers in preflight response.`

I'm rolling back changes made in https://github.com/vechain/vechain-kit/pull/89

Reopening ticket #74 

# Updated packages (if any):

[ ] next-template
[ ] homepage
[ x ] vechain-kit
