### PR TITLE
Feat: Custom token support

### DIFF
--- a/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
@@ -4,7 +4,7 @@ import { useColorMode } from '@chakra-ui/react';
 import dynamic from 'next/dynamic';
 import '../../../i18n';
 import { useTranslation } from 'react-i18next';
-import { NETWORK_TYPE } from "@vechain-kit/config/network";
+import { NETWORK_TYPE } from '@vechain-kit/config/network';
 
 // Dynamic import is used here for several reasons:
 // 1. The VechainKit component uses browser-specific APIs that aren't available during server-side rendering
@@ -75,7 +75,7 @@ export function VechainKitProviderWrapper({ children }: Props) {
             network={{
                 type: process.env.NEXT_PUBLIC_NETWORK_TYPE! as NETWORK_TYPE,
             }}
-            developerMode={true}
+            allowCustomTokens={true}
         >
             {children}
         </VeChainKitProvider>

--- a/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
@@ -56,6 +56,15 @@ export function VechainKitProviderWrapper({ children }: Props) {
                     },
                 },
             }}
+            loginMethods={[
+                // { method: 'email', gridColumn: 4 },
+                // { method: 'google', gridColumn: 4 },
+                { method: 'vechain', gridColumn: 4 },
+                { method: 'dappkit', gridColumn: 4 },
+                { method: 'ecosystem', gridColumn: 4 },
+                // { method: 'passkey', gridColumn: 1 },
+                // { method: 'more', gridColumn: 1 },
+            ]}
             loginModalUI={{
                 logo: appLogo,
                 description:
@@ -66,6 +75,7 @@ export function VechainKitProviderWrapper({ children }: Props) {
             network={{
                 type: process.env.NEXT_PUBLIC_NETWORK_TYPE! as NETWORK_TYPE,
             }}
+            developerMode={true}
         >
             {children}
         </VeChainKitProvider>

--- a/packages/vechain-kit/src/components/AccountModal/AccountModal.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/AccountModal.tsx
@@ -27,6 +27,7 @@ import { AppOverviewContent } from './Contents/Ecosystem/AppOverviewContent';
 import { DisconnectConfirmContent } from './Contents/Account/DisconnectConfirmContent';
 import { CustomizationContent, CustomizationSummaryContent } from './Contents';
 import { SuccessfulOperationContent } from './Contents/SuccessfulOperation/SuccessfulOperationContent';
+import { ManageCustomTokenContent } from './Contents/ManageCustomToken';
 
 type Props = {
     isOpen: boolean;
@@ -178,6 +179,12 @@ export const AccountModal = ({
             case 'embedded-wallet':
                 return (
                     <EmbeddedWalletContent
+                        setCurrentContent={setCurrentContent}
+                    />
+                );
+            case 'add-custom-token':
+                return (
+                    <ManageCustomTokenContent
                         setCurrentContent={setCurrentContent}
                     />
                 );

--- a/packages/vechain-kit/src/components/AccountModal/Components/Tabs/Contents/AssetsTabPanel.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Components/Tabs/Contents/AssetsTabPanel.tsx
@@ -17,7 +17,7 @@ export type AssetsTabPanelProps = {
 export const AssetsTabPanel = ({ setCurrentContent }: AssetsTabPanelProps) => {
     const { account } = useWallet();
     const { balances, prices } = useBalances({ address: account?.address });
-    const { network, developerMode } = useVeChainKitConfig();
+    const { network, allowCustomTokens } = useVeChainKitConfig();
     const { customTokens } = useCustomTokens();
     const { t } = useTranslation();
 
@@ -97,7 +97,7 @@ export const AssetsTabPanel = ({ setCurrentContent }: AssetsTabPanelProps) => {
             ))}
 
             {/* Plus Icon to add a new token */}
-            {developerMode && (
+            {allowCustomTokens && (
                 <Button
                     size="sm"
                     variant="ghost"

--- a/packages/vechain-kit/src/components/AccountModal/Contents/ManageCustomToken/ManageCustomTokenContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ManageCustomToken/ManageCustomTokenContent.tsx
@@ -1,0 +1,214 @@
+import {
+    ModalBody,
+    ModalCloseButton,
+    ModalHeader,
+    VStack,
+    Input,
+    Button,
+    Text,
+    Box,
+    HStack,
+    ModalFooter,
+    FormControl,
+    FormLabel,
+    Image,
+} from '@chakra-ui/react';
+import { ModalBackButton, StickyHeaderContainer } from '@/components';
+import { AccountModalContentTypes } from '../../Types';
+import { useTranslation } from 'react-i18next';
+import { useVeChainKitConfig } from '@/providers';
+import { useForm } from 'react-hook-form';
+import { useCustomTokens } from '@/hooks/api/wallet/useCustomTokens';
+import { humanAddress, TOKEN_LOGOS } from '@/utils';
+import { IoTrashBin } from 'react-icons/io5';
+
+export type ManageCustomTokenContentProps = {
+    setCurrentContent: React.Dispatch<
+        React.SetStateAction<AccountModalContentTypes>
+    >;
+};
+
+// Add form values type
+type FormValues = {
+    newTokenAddress: string;
+};
+
+export const ManageCustomTokenContent = ({
+    setCurrentContent,
+}: ManageCustomTokenContentProps) => {
+    const { t } = useTranslation();
+    const { darkMode: isDark } = useVeChainKitConfig();
+    const { addToken, removeToken, isTokenIncluded, customTokens } =
+        useCustomTokens();
+
+    // Form setup with validation rules
+    const {
+        register,
+        setError,
+        formState: { errors, isValid },
+        handleSubmit,
+    } = useForm<FormValues>({
+        defaultValues: {
+            newTokenAddress: '',
+        },
+        mode: 'onChange',
+    });
+
+    const onSubmit = async (data: FormValues) => {
+        if (!data.newTokenAddress) return;
+
+        if (isTokenIncluded(data.newTokenAddress)) {
+            return setError('newTokenAddress', {
+                type: 'manual',
+                message: t('Token already added'),
+            });
+        }
+
+        addToken(data.newTokenAddress);
+    };
+
+    return (
+        <>
+            <StickyHeaderContainer>
+                <ModalHeader
+                    fontSize={'md'}
+                    fontWeight={'500'}
+                    textAlign={'center'}
+                    color={isDark ? '#dfdfdd' : '#4d4d4d'}
+                >
+                    {t('Manage Custom Tokens')}
+                </ModalHeader>
+                <ModalBackButton onClick={() => setCurrentContent('main')} />
+                <ModalCloseButton />
+            </StickyHeaderContainer>
+
+            <ModalBody>
+                <VStack spacing={4} align="stretch" position="relative">
+                    {/* Input Section */}
+                    <Box
+                        p={6}
+                        borderRadius="xl"
+                        bg={isDark ? '#1a1a1a' : 'gray.50'}
+                    >
+                        <VStack align="stretch" spacing={2}>
+                            <FormControl isInvalid={!!errors.newTokenAddress}>
+                                <FormLabel fontSize="sm" fontWeight="medium">
+                                    {t('Token Contract Address')}
+                                </FormLabel>
+                                <Input
+                                    {...register('newTokenAddress', {
+                                        required: t('Address is required'),
+                                        pattern: {
+                                            value: /^0x[a-fA-F0-9]{40}$/,
+                                            message: t(
+                                                'Please enter a valid contract address',
+                                            ),
+                                        },
+                                        validate: (value) =>
+                                            /^0x[a-fA-F0-9]{40}$/.test(value) ||
+                                            t('Invalid contract address'),
+                                    })}
+                                    placeholder="0x..."
+                                    variant="outline"
+                                    fontSize="md"
+                                    fontWeight="medium"
+                                />
+                                {errors.newTokenAddress && (
+                                    <Text color="red.500" fontSize="sm">
+                                        {errors.newTokenAddress.message}
+                                    </Text>
+                                )}
+                            </FormControl>
+                        </VStack>
+                    </Box>
+
+                    {/* Existing Tokens List */}
+                    {customTokens.length > 0 && (
+                        <Box
+                            p={4}
+                            borderRadius="xl"
+                            bg={isDark ? '#ffffff0f' : 'gray.50'}
+                        >
+                            <Text fontSize="sm" fontWeight="medium" mb={2}>
+                                {t('Existing Custom Tokens')}
+                            </Text>
+                            <VStack align="stretch" spacing={2}>
+                                {customTokens.map((token) => (
+                                    <HStack
+                                        key={token.address}
+                                        justify="space-between"
+                                        fontSize="sm"
+                                        p={2}
+                                        borderRadius="md"
+                                        bg={isDark ? '#2a2a2a' : 'gray.100'}
+                                    >
+                                        <HStack>
+                                            <Image
+                                                src={TOKEN_LOGOS[token?.symbol]}
+                                                alt={`${token.symbol} logo`}
+                                                boxSize="20px"
+                                                borderRadius="full"
+                                                fallback={
+                                                    <Box
+                                                        boxSize="20px"
+                                                        borderRadius="full"
+                                                        bg="whiteAlpha.200"
+                                                        display="flex"
+                                                        alignItems="center"
+                                                        justifyContent="center"
+                                                    >
+                                                        <Text
+                                                            fontSize="8px"
+                                                            fontWeight="bold"
+                                                        >
+                                                            {token.symbol?.slice(
+                                                                0,
+                                                                3,
+                                                            )}
+                                                        </Text>
+                                                    </Box>
+                                                }
+                                            />
+                                            <Text fontWeight="medium">
+                                                {token.symbol ?? 'Unknown'}
+                                            </Text>
+                                        </HStack>
+                                        <Text opacity={0.7}>
+                                            {humanAddress(
+                                                token.address ?? '',
+                                                4,
+                                                4,
+                                            )}
+                                        </Text>
+                                        <Button
+                                            size="sm"
+                                            variant="ghost"
+                                            colorScheme="red"
+                                            borderRadius="md"
+                                            p={2}
+                                            onClick={() =>
+                                                removeToken(token.address)
+                                            }
+                                        >
+                                            <IoTrashBin size={16} />
+                                        </Button>
+                                    </HStack>
+                                ))}
+                            </VStack>
+                        </Box>
+                    )}
+                </VStack>
+            </ModalBody>
+
+            <ModalFooter>
+                <Button
+                    variant="vechainKitSecondary"
+                    isDisabled={!isValid}
+                    onClick={handleSubmit(onSubmit)}
+                >
+                    {t('Add Token')}
+                </Button>
+            </ModalFooter>
+        </>
+    );
+};

--- a/packages/vechain-kit/src/components/AccountModal/Contents/ManageCustomToken/index.ts
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ManageCustomToken/index.ts
@@ -1,0 +1,1 @@
+export { ManageCustomTokenContent } from './ManageCustomTokenContent';

--- a/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
@@ -212,7 +212,7 @@ export const SendTokenSummaryContent = ({
                             imageSrc={account?.image ?? ''}
                             imageAlt="From account"
                             balance={selectedToken.numericBalance}
-                            symbol={selectedToken.symbol}
+                            tokenAddress={selectedToken.address}
                         />
 
                         <AddressDisplayCard
@@ -221,7 +221,7 @@ export const SendTokenSummaryContent = ({
                             domain={resolvedDomain}
                             imageSrc={toImageSrc ?? ''}
                             imageAlt="To account"
-                            symbol={selectedToken.symbol}
+                            tokenAddress={selectedToken.address}
                         />
 
                         <Divider />

--- a/packages/vechain-kit/src/components/AccountModal/Types/Types.ts
+++ b/packages/vechain-kit/src/components/AccountModal/Types/Types.ts
@@ -21,6 +21,7 @@ export type AccountModalContentTypes =
     | 'notifications'
     | 'privy-linked-accounts'
     | 'account-customization'
+    | 'add-custom-token'
     | {
           type: 'successful-operation';
           props: SuccessfulOperationContentProps;

--- a/packages/vechain-kit/src/components/common/AddressDisplayCard.tsx
+++ b/packages/vechain-kit/src/components/common/AddressDisplayCard.tsx
@@ -18,7 +18,7 @@ type AddressDisplayCardProps = {
     imageAlt?: string;
     hideAddress?: boolean;
     balance?: number;
-    symbol?: string;
+    tokenAddress?: string;
 };
 
 export const AddressDisplayCard = ({
@@ -29,7 +29,7 @@ export const AddressDisplayCard = ({
     imageAlt = 'Account',
     hideAddress = false,
     balance,
-    symbol,
+    tokenAddress,
 }: AddressDisplayCardProps) => {
     const { darkMode: isDark } = useVeChainKitConfig();
     const { t } = useTranslation();
@@ -38,13 +38,17 @@ export const AddressDisplayCard = ({
         address: address,
     });
 
+    // Convert balances into lookup maps for quick access
+    const balanceMap = new Map(
+        balances.map(({ address, value }) => [address, value]),
+    );
+    const symbol = balances.find(({ address }) => address === tokenAddress); //TODO: Insted of using find, useBalances should return a map to easy access
+
     // Use the specific token balance if symbol is provided
     const displayBalance =
         balance !== undefined
             ? balance
-            : (symbol &&
-                  balances[symbol.toLowerCase() as keyof typeof balances]) ||
-              0;
+            : (tokenAddress && balanceMap.get(tokenAddress)) || 0;
 
     return (
         <Box

--- a/packages/vechain-kit/src/hooks/api/utility/index.ts
+++ b/packages/vechain-kit/src/hooks/api/utility/index.ts
@@ -1,3 +1,5 @@
 export * from './useGetChainId';
 export * from './useGetNodeUrl';
 export * from './useContractVersion';
+export * from './useGetCustomTokenBalances';
+export * from './useGetCustomTokenInfo';

--- a/packages/vechain-kit/src/hooks/api/utility/useGetCustomTokenBalances.ts
+++ b/packages/vechain-kit/src/hooks/api/utility/useGetCustomTokenBalances.ts
@@ -1,0 +1,65 @@
+import { useQueries } from '@tanstack/react-query';
+import { useConnex } from '@vechain/dapp-kit-react';
+import { ERC20__factory } from '../../../contracts/typechain-types';
+import { formatEther } from 'viem';
+import { humanNumber } from '@/utils';
+import { useCustomTokens } from '../wallet/useCustomTokens';
+import { CustomTokenInfo } from './useGetCustomTokenInfo';
+import { TokenBalance } from '../vebetterdao';
+
+const ERC20Interface = ERC20__factory.createInterface();
+
+export type TokenWithBalance = CustomTokenInfo & TokenBalance;
+
+/**
+ *  Get the b3tr balance of an address from the contract
+ * @param thor  The thor instance
+ * @param network  The network type
+ * @param address  The address to get the balance of. If not provided, will return an error (for better react-query DX)
+ * @returns Balance of the token in the form of {@link TokenBalance} (original, scaled down and formatted)
+ */
+export const getCustomTokenBalance = async (
+    thor: Connex.Thor,
+    token: CustomTokenInfo,
+    address?: string,
+): Promise<TokenWithBalance> => {
+    const functionFragment =
+        ERC20Interface.getFunction('balanceOf').format('json');
+
+    const res = await thor
+        .account(token.address)
+        .method(JSON.parse(functionFragment))
+        .call(address);
+
+    if (res.reverted) throw new Error('Reverted');
+
+    const original = res.decoded[0];
+    const scaled = formatEther(original);
+    const formatted = scaled === '0' ? '0' : humanNumber(scaled);
+
+    return {
+        ...token,
+        original,
+        scaled,
+        formatted,
+    };
+};
+
+export const getCustomTokenBalanceQueryKey = (
+    tokenAddress: string,
+    address?: string,
+) => ['VECHAIN_KIT_CUSTOM_TOKEN_BALANCE', address, tokenAddress];
+
+export const useGetCustomTokenBalances = (address?: string) => {
+    const { thor } = useConnex();
+    const { customTokens } = useCustomTokens();
+
+    return useQueries({
+        queries: customTokens.map((token) => ({
+            queryKey: getCustomTokenBalanceQueryKey(token.address, address),
+            queryFn: async () => {
+                return await getCustomTokenBalance(thor, token, address);
+            },
+        })),
+    });
+};

--- a/packages/vechain-kit/src/hooks/api/utility/useGetCustomTokenInfo.ts
+++ b/packages/vechain-kit/src/hooks/api/utility/useGetCustomTokenInfo.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnex } from '@vechain/dapp-kit-react';
+import { ERC20__factory } from '../../../contracts/typechain-types';
+import { useVeChainKitConfig } from '@/providers';
+import { abi } from 'thor-devkit';
+
+const ERC20Interface = ERC20__factory.createInterface();
+
+export type CustomTokenInfo = {
+    name: string;
+    address: string;
+    decimals: string;
+    symbol: string;
+};
+
+export const getTokenInfo = async (
+    thor: Connex.Thor,
+    tokenAddress: string,
+): Promise<CustomTokenInfo> => {
+    if (!tokenAddress) throw new Error('Token address is required');
+
+    // Define the function fragments for name, symbol, decimals
+    const nameFragment = ERC20Interface.getFunction('name').format('json');
+    const symbolFragment = ERC20Interface.getFunction('symbol').format('json');
+    const decimalsFragment =
+        ERC20Interface.getFunction('decimals').format('json');
+
+    // Get the ABI for the function fragments
+    const nameAbi = new abi.Function(JSON.parse(nameFragment));
+    const symbolAbi = new abi.Function(JSON.parse(symbolFragment));
+    const decimalsAbi = new abi.Function(JSON.parse(decimalsFragment));
+
+    const abis = [nameAbi, symbolAbi, decimalsAbi];
+    // Create clauses for all function calls
+    const clauses = abis.map((funcAbi) => ({
+        to: tokenAddress,
+        value: 0,
+        data: funcAbi.encode(),
+    }));
+
+    const infoResponse = await thor.explain(clauses).execute();
+
+    // Decode responses using the correct ABI
+    const [name, symbol, decimals] = infoResponse.map((res, index) => {
+        const functionAbi = abis[index];
+        return functionAbi.decode(res.data)[0];
+    });
+
+    return {
+        name,
+        address: tokenAddress,
+        decimals,
+        symbol,
+    };
+};
+
+export const getCustomTokenInfo = (tokenAddress: string) => [
+    'VECHAIN_KIT_CUSTOM_TOKEN_BALANCE',
+    tokenAddress,
+];
+
+export const useGetCustomTokenInfo = (tokenAddress: string) => {
+    const { thor } = useConnex();
+    const { network } = useVeChainKitConfig();
+
+    return useQuery({
+        queryKey: getCustomTokenInfo(tokenAddress),
+        queryFn: async () => getTokenInfo(thor, tokenAddress),
+        enabled: !!thor && !!network.type && !!tokenAddress,
+    });
+};

--- a/packages/vechain-kit/src/hooks/api/wallet/useCustomTokens.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useCustomTokens.ts
@@ -1,0 +1,46 @@
+import { useConnex, useLocalStorage } from '@/hooks';
+import {
+    CustomTokenInfo,
+    getTokenInfo,
+} from '../utility/useGetCustomTokenInfo';
+import { compareAddresses } from '@/utils';
+
+export const useCustomTokens = () => {
+    const [customTokens, setCustomTokens] = useLocalStorage<CustomTokenInfo[]>(
+        'vechain_kit_custom_tokens',
+        [],
+    );
+    const { thor } = useConnex();
+
+    const addToken = async (address: CustomTokenInfo['address']) => {
+        if (!isTokenIncluded(address)) {
+            const tokenInfo = await getTokenInfo(thor, address);
+
+            const token: CustomTokenInfo = {
+                ...tokenInfo,
+                address,
+            };
+
+            setCustomTokens([...customTokens, token]);
+        }
+    };
+
+    const removeToken = (address: string) => {
+        setCustomTokens(
+            customTokens.filter((t: CustomTokenInfo) => t.address !== address),
+        );
+    };
+
+    const isTokenIncluded = (address: string) => {
+        return customTokens.some((t: CustomTokenInfo) =>
+            compareAddresses(t.address, address),
+        );
+    };
+
+    return {
+        customTokens,
+        addToken,
+        removeToken,
+        isTokenIncluded,
+    };
+};

--- a/packages/vechain-kit/src/hooks/api/wallet/useRefreshBalances.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useRefreshBalances.ts
@@ -3,17 +3,25 @@ import { useWallet } from './useWallet';
 import {
     getAccountBalanceQueryKey,
     getB3trBalanceQueryKey,
-    getVot3BalanceQueryKey,
     getVeDelegateBalanceQueryKey,
+    getVot3BalanceQueryKey,
     getTokenUsdPriceQueryKey,
+    getCustomTokenBalanceQueryKey,
 } from '..';
+import { useCustomTokens } from './useCustomTokens';
 
 export const useRefreshBalances = () => {
     const queryClient = useQueryClient();
     const { account } = useWallet();
+    const { customTokens } = useCustomTokens();
 
     const refresh = async () => {
         const address = account?.address ?? '';
+
+        // Generate query keys for custom token balances
+        const customTokenQueryKeys = customTokens.map((token) =>
+            getCustomTokenBalanceQueryKey(token.address, address),
+        );
 
         // First invalidate all queries
         await Promise.all([
@@ -38,6 +46,9 @@ export const useRefreshBalances = () => {
             queryClient.cancelQueries({
                 queryKey: getTokenUsdPriceQueryKey('B3TR'),
             }),
+            ...customTokenQueryKeys.map((queryKey) =>
+                queryClient.cancelQueries({ queryKey }),
+            ),
         ]);
 
         // Then refetch all queries
@@ -63,6 +74,9 @@ export const useRefreshBalances = () => {
             queryClient.refetchQueries({
                 queryKey: getTokenUsdPriceQueryKey('B3TR'),
             }),
+            ...customTokenQueryKeys.map((queryKey) =>
+                queryClient.refetchQueries({ queryKey }),
+            ),
         ]);
     };
 

--- a/packages/vechain-kit/src/languages/en.json
+++ b/packages/vechain-kit/src/languages/en.json
@@ -404,5 +404,12 @@
     "Already have an app account?": "Already have an app account?",
     "Other options": "Other options",
     "Link External Wallet": "Link External Wallet",
-    "Connect an external wallet for easier access": "Connect an external wallet for easier access"
+    "Connect an external wallet for easier access": "Connect an external wallet for easier access",
+    "Token Contract Address": "Token Contract Address",
+    "Please enter a valid contract address": "Please enter a valid contract address",
+    "Invalid contract address": "Invalid contract address",
+    "Existing Custom Tokens": "Existing Custom Tokens",
+    "Add Token": "Add Token",
+    "Token already added": "Token already added",
+    "Manage Custom Tokens": "Manage Custom Tokens"
 }

--- a/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
+++ b/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
@@ -98,7 +98,7 @@ export type VechainKitProviderProps = {
             options?: Connex.Signer.CertOptions;
         };
     };
-    developerMode?: boolean;
+    allowCustomTokens?: boolean;
 };
 
 type VeChainKitConfig = {
@@ -112,7 +112,7 @@ type VeChainKitConfig = {
     i18n?: VechainKitProviderProps['i18n'];
     language?: VechainKitProviderProps['language'];
     network: VechainKitProviderProps['network'];
-    developerMode?: boolean;
+    allowCustomTokens?: boolean;
 };
 
 /**
@@ -203,7 +203,7 @@ export const VeChainKitProvider = (
         i18n: i18nConfig,
         language = 'en',
         network,
-        developerMode,
+        allowCustomTokens,
     } = validatedProps;
 
     // Remove the validateLoginMethods call since it's now handled in validateConfig
@@ -267,7 +267,7 @@ export const VeChainKitProvider = (
                         i18n: i18nConfig,
                         language,
                         network,
-                        developerMode,
+                        allowCustomTokens,
                     }}
                 >
                     <PrivyProvider

--- a/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
+++ b/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
@@ -98,6 +98,7 @@ export type VechainKitProviderProps = {
             options?: Connex.Signer.CertOptions;
         };
     };
+    developerMode?: boolean;
 };
 
 type VeChainKitConfig = {
@@ -111,6 +112,7 @@ type VeChainKitConfig = {
     i18n?: VechainKitProviderProps['i18n'];
     language?: VechainKitProviderProps['language'];
     network: VechainKitProviderProps['network'];
+    developerMode?: boolean;
 };
 
 /**
@@ -201,6 +203,7 @@ export const VeChainKitProvider = (
         i18n: i18nConfig,
         language = 'en',
         network,
+        developerMode,
     } = validatedProps;
 
     // Remove the validateLoginMethods call since it's now handled in validateConfig
@@ -264,6 +267,7 @@ export const VeChainKitProvider = (
                         i18n: i18nConfig,
                         language,
                         network,
+                        developerMode,
                     }}
                 >
                     <PrivyProvider


### PR DESCRIPTION

# Description

This PR introduces **custom token management** within the `vechain-kit`, allowing users to **add, remove, and view custom ERC-20 tokens** alongside native assets.  

Fixes #103

### **Key Changes**  
- **Added support for custom tokens**  
  - Users can now **add ERC-20 tokens** via their contract address.  
  - Existing custom tokens are **displayed with their address and symbol**.  
  - Tokens are stored and persisted for better user experience.  
  
- **Developer Mode**  
  - Now a new optional prop can be provide, `developerMode` which enables this UI to be accessed
  PS: Currently it's handled by the client provider only, but could be exposed through the UI too


# Updated packages (if any):

- [ ] next-template
- [ ] homepage
- [x]  vechain-kit

### Screen Recording


https://github.com/user-attachments/assets/7429d7a9-f12a-4bc4-a8e8-961e6320bc36

