### PR TITLE
Feat/export-dapp-kit-hooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -4,7 +4,7 @@ title: "🐛 [BUG] - <title>"
 labels: [
 "bug"
 ]
-projects: ["vechain/projects/51", "vechain/projects/9"]
+projects: ["VeChain-Kit"]
 body:
 - type: textarea
   id: description

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -4,7 +4,7 @@ title: "💡 [REQUEST] - <title>"
 labels: [
 "feature"
 ]
-projects: ["vechain/projects/51", "vechain/projects/9"]
+projects: [""VeChain-Kit""]
 body:
 - type: textarea
   id: summary

--- a/examples/homepage/src/app/components/features/LoginUIControl/LoginUIControl.tsx
+++ b/examples/homepage/src/app/components/features/LoginUIControl/LoginUIControl.tsx
@@ -1,12 +1,17 @@
 'use client';
 
 import { VStack, Text, Box, Grid, Button } from '@chakra-ui/react';
-import { WalletButton, useConnectModal } from '@vechain/vechain-kit';
+import {
+    WalletButton,
+    useConnectModal,
+    useDAppKitWalletModal,
+} from '@vechain/vechain-kit';
 import { MdLogin } from 'react-icons/md';
 import { CollapsibleCard } from '../../ui/CollapsibleCard';
 
 export const LoginUIControl = () => {
     const { open } = useConnectModal();
+    const { open: openWalletModal } = useDAppKitWalletModal();
 
     return (
         <CollapsibleCard
@@ -126,6 +131,25 @@ export const LoginUIControl = () => {
                                     borderRadius="full"
                                 >
                                     custom button (with onClick)
+                                </Text>
+                            </VStack>
+
+                            <VStack alignItems="flex-start" spacing={2}>
+                                <Box w={'fit-content'}>
+                                    <Button onClick={openWalletModal}>
+                                        Open only "Connect Wallet"
+                                    </Button>
+                                </Box>
+                                <Text
+                                    fontSize="sm"
+                                    fontWeight="medium"
+                                    color="blue.300"
+                                    bg="whiteAlpha.100"
+                                    px={3}
+                                    py={1}
+                                    borderRadius="full"
+                                >
+                                    aka: dapp-kit connect modal
                                 </Text>
                             </VStack>
                         </VStack>

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -58,7 +58,7 @@
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "translo-cli": "^1.0.6",
-        "viem": "^2.21.3",
+        "viem": "^2.21.9",
         "wagmi": "^2.13.4"
     },
     "devDependencies": {

--- a/packages/vechain-kit/src/components/ConnectModal/Components/DappKitButton.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/DappKitButton.tsx
@@ -1,5 +1,5 @@
 import { GridItem, Icon } from '@chakra-ui/react';
-import { useWalletModal } from '@vechain/dapp-kit-react';
+import { useDAppKitWalletModal } from '@/hooks';
 import { ConnectionButton } from '@/components';
 import { useTranslation } from 'react-i18next';
 import { IoIosArrowForward } from 'react-icons/io';
@@ -12,7 +12,7 @@ type Props = {
 
 export const DappKitButton = ({ isDark, gridColumn = 2 }: Props) => {
     const { t } = useTranslation();
-    const { open: openDappKitModal } = useWalletModal();
+    const { open: openDappKitModal } = useDAppKitWalletModal();
 
     return (
         <GridItem colSpan={gridColumn ? gridColumn : 2} w={'full'}>

--- a/packages/vechain-kit/src/components/WalletButton/WalletButton.tsx
+++ b/packages/vechain-kit/src/components/WalletButton/WalletButton.tsx
@@ -4,8 +4,7 @@ import {
     useDisclosure,
     useMediaQuery,
 } from '@chakra-ui/react';
-import { useWallet } from '@/hooks';
-import { useWallet as useDappKitWallet } from '@vechain/dapp-kit-react';
+import { useWallet, useDAppKitWallet } from '@/hooks';
 import { ConnectModal, AccountModal } from '@/components';
 import { ConnectedWallet } from './ConnectedWallet';
 import { WalletDisplayVariant } from './types';
@@ -30,7 +29,7 @@ export const WalletButton = ({
     const { darkMode } = useVeChainKitConfig();
 
     const { connection, account } = useWallet();
-    const { setSource, connect } = useDappKitWallet();
+    const { setSource, connect } = useDAppKitWallet();
 
     const [isMobile] = useMediaQuery('(max-width: 768px)');
 

--- a/packages/vechain-kit/src/components/index.ts
+++ b/packages/vechain-kit/src/components/index.ts
@@ -7,3 +7,4 @@ export * from './common';
 export * from './LoginLoadingModal';
 export * from './EcosystemModal';
 export * from './ProfileCard';
+export { WalletButton as DAppKitWalletButton } from '@vechain/dapp-kit-react';

--- a/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useLoginWithOAuth, usePrivy, User } from '@privy-io/react-auth';
-import { useWallet as useDappKitWallet } from '@vechain/dapp-kit-react';
 import {
     useGetChainId,
     useGetNodeUrl,
@@ -9,6 +8,7 @@ import {
     useGetAvatar,
     useGetTextRecords,
     useVechainDomain,
+    useDAppKitWallet,
 } from '@/hooks';
 import {
     compareAddresses,
@@ -73,7 +73,7 @@ export const useWallet = (): UseWalletReturnType => {
     const { user, authenticated, logout, ready } = usePrivy();
     const { data: chainId } = useGetChainId();
     const { account: dappKitAccount, disconnect: dappKitDisconnect } =
-        useDappKitWallet();
+        useDAppKitWallet();
 
     const { getConnectionCache, clearConnectionCache } =
         useCrossAppConnectionCache();

--- a/packages/vechain-kit/src/hooks/index.ts
+++ b/packages/vechain-kit/src/hooks/index.ts
@@ -1,7 +1,8 @@
 export { usePrivy } from '@privy-io/react-auth';
 export {
     useConnex,
-    useWallet as useDappKitWallet,
+    useWallet as useDAppKitWallet,
+    useWalletModal as useDAppKitWalletModal,
 } from '@vechain/dapp-kit-react';
 export * from './api';
 export * from './modals';

--- a/packages/vechain-kit/src/hooks/signing/useSignTypedData.ts
+++ b/packages/vechain-kit/src/hooks/signing/useSignTypedData.ts
@@ -3,8 +3,7 @@
 import { useCallback, useState } from 'react';
 import { SignTypedDataParams } from '@privy-io/react-auth';
 import { usePrivyWalletProvider } from '@/providers';
-import { useWallet } from '@/hooks';
-import { useWallet as useDappKitWallet } from '@vechain/dapp-kit-react';
+import { useWallet, useDAppKitWallet } from '@/hooks';
 
 type UseSignTypedDataReturnValue = {
     signTypedData: (data: SignTypedDataParams) => Promise<string>;
@@ -28,7 +27,7 @@ export const useSignTypedData = (): UseSignTypedDataReturnValue => {
     const { connection } = useWallet();
     const privyWalletProvider = usePrivyWalletProvider();
 
-    const { signTypedData: signTypedDataDappKit } = useDappKitWallet();
+    const { signTypedData: signTypedDataDappKit } = useDAppKitWallet();
     const signTypedData = useCallback(
         async (data: SignTypedDataParams): Promise<string> => {
             setIsSigningPending(true);

--- a/packages/vechain-kit/src/providers/ModalProvider.tsx
+++ b/packages/vechain-kit/src/providers/ModalProvider.tsx
@@ -10,7 +10,7 @@ import {
     AccountModalContentTypes,
     ConnectModal,
 } from '../components';
-import { useDappKitWallet } from '@/hooks';
+import { useDAppKitWallet } from '@/hooks';
 
 type ModalContextType = {
     // Connect Modal
@@ -46,7 +46,7 @@ export const useModal = () => {
 
 export const ModalProvider = ({ children }: { children: ReactNode }) => {
     const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
-    const { setSource, connect } = useDappKitWallet();
+    const { setSource, connect } = useDAppKitWallet();
     const openConnectModal = useCallback(() => {
         // If the user is in the veworld app, connect to the wallet
         if (window.vechain && window.vechain.isInAppBrowser) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10509,19 +10509,6 @@ ox@0.1.2:
     abitype "^1.0.6"
     eventemitter3 "5.0.1"
 
-ox@0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/ox/-/ox-0.6.5.tgz#e6506a589bd6af9b5fecfcb2c641b63c9882edb6"
-  integrity sha512-vmnH8KvMDwFZDbNY1mq2CBRBWIgSliZB/dFV0xKp+DfF/dJkTENt6nmA+DzHSSAgL/GO2ydjkXWvlndJgSY4KQ==
-  dependencies:
-    "@adraffy/ens-normalize" "^1.10.1"
-    "@noble/curves" "^1.6.0"
-    "@noble/hashes" "^1.5.0"
-    "@scure/bip32" "^1.5.0"
-    "@scure/bip39" "^1.4.0"
-    abitype "^1.0.6"
-    eventemitter3 "5.0.1"
-
 ox@0.6.7:
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/ox/-/ox-0.6.7.tgz#afd53f2ecef68b8526660e9d29dee6e6b599a832"
@@ -13076,20 +13063,6 @@ viem@^2.21.14:
     abitype "1.0.8"
     isows "1.0.6"
     ox "0.6.7"
-    ws "8.18.0"
-
-viem@^2.21.3:
-  version "2.22.9"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.22.9.tgz#14ddb7f1ccf900784e347e1aa157e8e58043b0c2"
-  integrity sha512-2yy46qYhcdo8GZggQ3Zoq9QCahI0goddzpVI/vSnTpcClQBSDxYRCuAqRzzLqjvJ7hS0UYgplC7eRkM2sYgflw==
-  dependencies:
-    "@noble/curves" "1.7.0"
-    "@noble/hashes" "1.6.1"
-    "@scure/bip32" "1.6.0"
-    "@scure/bip39" "1.5.0"
-    abitype "1.0.7"
-    isows "1.0.6"
-    ox "0.6.5"
     ws "8.18.0"
 
 viem@^2.21.45:


### PR DESCRIPTION
# Description

Allowing using the kit but with only the wallets without seeing the vechain kit login modal. (Needed to vevote)
Also bumped viem since it was having issues with last privy upgrade.

https://github.com/user-attachments/assets/d050dcc3-2858-440b-9835-21acfb0304ec

# Updated packages (if any):

[ ] next-template
[x] homepage
[x] vechain-kit
