### PR TITLE
Deploy to old domain

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@ Closes #(issue)
 
 ### Updated packages (if any):
 
--   [] next-template
--   [] homepage
--   [] vechain-kit
+-  [ ] next-template
+-  [ ] homepage
+-  [ ] vechain-kit

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -53,6 +53,20 @@ jobs:
               with:
                   path: './examples/homepage/dist'
 
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.AWS_ACC_ROLE }}
+                  aws-region: eu-west-1
+
+            - name: Deploy to S3
+              run: |
+                  aws s3 sync ./examples/homepage/dist s3://${{ secrets.AWS_BUCKET_NAME }} --delete
+
+            - name: Cloudfront Invalidation
+              run: |
+                  AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/' '/*'
+
     deploy:
         needs: build
         permissions:


### PR DESCRIPTION
### Description

- Updated the deployment workflow to deploy to vechain-kit.vechain.org on AWS for now as a fallback before we migrate vechainkit.vechain.org from GH pages to AWS
- Small update to PR template to display empty checkboxes by default

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [ ] vechain-kit
