### PR TITLE
Fix/account upgrade modal

### DIFF
--- a/examples/homepage/src/app/components/features/FeaturesToTry/FeaturesToTry.tsx
+++ b/examples/homepage/src/app/components/features/FeaturesToTry/FeaturesToTry.tsx
@@ -16,7 +16,7 @@ import {
     useAccessAndSecurityModal,
     useExploreEcosystemModal,
     useNotificationsModal,
-    useAccountCustomizationModal,
+    useProfileModal,
     useFAQModal,
     useReceiveModal,
 } from '@vechain/vechain-kit';
@@ -33,8 +33,7 @@ export function FeaturesToTry() {
 
     // Use the modal hooks
     const { open: openChooseNameModal } = useChooseNameModal();
-    const { open: openAccountCustomizationModal } =
-        useAccountCustomizationModal();
+    const { open: openProfileModal } = useProfileModal();
     const { open: openSendTokenModal } = useSendTokenModal();
     const { open: openAccessAndSecurityModal } = useAccessAndSecurityModal();
     const { open: openExploreEcosystemModal } = useExploreEcosystemModal();
@@ -56,9 +55,9 @@ export function FeaturesToTry() {
         {
             title: 'Customize Profile',
             description:
-                'Customize your account with a profile image, display name, bio and more to enhance your identity across VeChain applications.',
+                'Show the user his profile and allow them to customize it with a profile image, display name, bio and more to enhance their identity across VeChain applications.',
             icon: CgProfile,
-            content: openAccountCustomizationModal,
+            content: openProfileModal,
         },
         {
             title: 'Transfer Assets',
@@ -76,7 +75,7 @@ export function FeaturesToTry() {
         {
             title: 'Access & Security',
             description:
-                'Secure your embedded wallet with proper backup procedures and update your login methods.',
+                'Allow the user to secure his embedded wallet with proper backup procedures, update his login methods, add MFA and more.',
             icon: RiShieldKeyholeLine,
             content: openAccessAndSecurityModal,
             disabled: !connection.isConnectedWithPrivy,

--- a/packages/vechain-kit/src/components/AccountModal/Components/ActionButton.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Components/ActionButton.tsx
@@ -97,7 +97,7 @@ export const ActionButton = ({
                     justifyContent={'flex-start'}
                     alignItems={'flex-start'}
                 >
-                    <HStack justify={'flex-start'}>
+                    <HStack justify={'flex-start'} alignItems={'baseline'}>
                         <Text fontSize={'sm'} fontWeight={'400'}>
                             {title}
                         </Text>

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Account/AccessAndSecurityContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Account/AccessAndSecurityContent.tsx
@@ -7,6 +7,7 @@ import {
     Text,
     Icon,
     Button,
+    Box,
 } from '@chakra-ui/react';
 import {
     usePrivy,
@@ -26,7 +27,7 @@ import { ActionButton } from '../../Components';
 import { MdOutlineNavigateNext } from 'react-icons/md';
 import { GrUserAdmin } from 'react-icons/gr';
 import { HiOutlineWallet, HiOutlineShieldCheck } from 'react-icons/hi2';
-import { IoShieldOutline } from 'react-icons/io5';
+import { IoCogSharp, IoShieldOutline } from 'react-icons/io5';
 import { GiHouseKeys } from 'react-icons/gi';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 
@@ -85,7 +86,37 @@ export const AccessAndSecurityContent = ({ setCurrentContent }: Props) => {
                         </Text>
                     </VStack>
 
-                    {/* TODO: Go to {{element}} website to manage your login methods and security settings. */}
+                    {upgradeRequired && (
+                        <ActionButton
+                            title={t('Upgrade Smart Account to V3')}
+                            description={t(
+                                'A new version is available for your account',
+                            )}
+                            onClick={() => {
+                                setCurrentContent({
+                                    type: 'upgrade-smart-account',
+                                    props: {
+                                        setCurrentContent,
+                                        initialContent: 'access-and-security',
+                                    },
+                                });
+                            }}
+                            leftIcon={IoCogSharp}
+                            extraContent={
+                                <Box
+                                    minWidth="8px"
+                                    height="8px"
+                                    bg="red.500"
+                                    borderRadius="full"
+                                    display="flex"
+                                    alignItems="center"
+                                    justifyContent="center"
+                                    ml={2}
+                                />
+                            }
+                        />
+                    )}
+
                     <ActionButton
                         title={t('Your embedded wallet')}
                         onClick={() => {
@@ -136,25 +167,6 @@ export const AccessAndSecurityContent = ({ setCurrentContent }: Props) => {
                         isDisabled={!connection.isConnectedWithSocialLogin}
                         leftIcon={HiOutlineShieldCheck}
                     />
-
-                    {upgradeRequired && (
-                        <ActionButton
-                            title={t('Upgrade Smart Account to V3')}
-                            description={t(
-                                'A new version is available for your account',
-                            )}
-                            onClick={() => {
-                                setCurrentContent({
-                                    type: 'upgrade-smart-account',
-                                    props: {
-                                        setCurrentContent,
-                                        initialContent: 'access-and-security',
-                                    },
-                                });
-                            }}
-                            leftIcon={HiOutlineShieldCheck}
-                        />
-                    )}
                 </VStack>
             </ModalBody>
             <ModalFooter w={'full'}>

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Account/SettingsContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Account/SettingsContent.tsx
@@ -5,12 +5,12 @@ import {
     ModalFooter,
     ModalHeader,
     Box,
-    Text,
     Button,
 } from '@chakra-ui/react';
 import {
     useCrossAppConnectionCache,
     useFetchAppInfo,
+    useUpgradeRequired,
     useWallet,
 } from '@/hooks';
 import { MdOutlineNavigateNext } from 'react-icons/md';
@@ -44,7 +44,8 @@ export const SettingsContent = ({
 
     const { privy } = useVeChainKitConfig();
 
-    const { connection, disconnect, account } = useWallet();
+    const { connection, disconnect, account, smartAccount, connectedWallet } =
+        useWallet();
 
     const { getConnectionCache } = useCrossAppConnectionCache();
     const connectionCache = getConnectionCache();
@@ -54,6 +55,12 @@ export const SettingsContent = ({
     const { getNotifications } = useNotifications();
     const notifications = getNotifications();
     const hasUnreadNotifications = notifications.some((n) => !n.isRead);
+
+    const { data: upgradeRequired } = useUpgradeRequired(
+        smartAccount?.address ?? '',
+        connectedWallet?.address ?? '',
+        3,
+    );
 
     useEffect(() => {
         if (contentRef.current) {
@@ -121,6 +128,19 @@ export const SettingsContent = ({
                             }}
                             leftIcon={IoShieldOutline}
                             rightIcon={MdOutlineNavigateNext}
+                            extraContent={
+                                upgradeRequired && (
+                                    <Box
+                                        minWidth="8px"
+                                        height="8px"
+                                        bg="red.500"
+                                        borderRadius="full"
+                                        display="flex"
+                                        alignItems="center"
+                                        justifyContent="center"
+                                    />
+                                )
+                            }
                         />
                     )}
 
@@ -154,23 +174,14 @@ export const SettingsContent = ({
                         extraContent={
                             hasUnreadNotifications && (
                                 <Box
-                                    minWidth="16px"
-                                    height="16px"
+                                    minWidth="8px"
+                                    height="8px"
                                     bg="red.500"
                                     borderRadius="full"
                                     display="flex"
                                     alignItems="center"
                                     justifyContent="center"
-                                    ml={2}
-                                >
-                                    <Text fontSize="xs" color="white">
-                                        {
-                                            notifications.filter(
-                                                (n) => !n.isRead,
-                                            ).length
-                                        }
-                                    </Text>
-                                </Box>
+                                />
                             )
                         }
                     />

--- a/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
@@ -19,7 +19,6 @@ import {
     useUpgradeSmartAccountModal,
     useWallet,
 } from '@/hooks';
-import { useEffect } from 'react';
 
 export type ChooseNameSummaryContentProps = {
     setCurrentContent: React.Dispatch<
@@ -76,18 +75,17 @@ export const ChooseNameSummaryContent = ({
     });
 
     const handleConfirm = async () => {
+        if (upgradeRequired) {
+            openUpgradeSmartAccountModal();
+            return;
+        }
+
         try {
             await sendTransaction();
         } catch (error) {
             console.error('Transaction failed:', error);
         }
     };
-
-    useEffect(() => {
-        if (upgradeRequired) {
-            openUpgradeSmartAccountModal();
-        }
-    }, [upgradeRequired, openUpgradeSmartAccountModal]);
 
     return (
         <>
@@ -129,7 +127,7 @@ export const ChooseNameSummaryContent = ({
                     transactionPendingText={t('Claiming name...')}
                     txReceipt={txReceipt}
                     buttonText={t('Confirm')}
-                    isDisabled={isTransactionPending || upgradeRequired}
+                    isDisabled={isTransactionPending}
                 />
             </ModalFooter>
         </>

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
@@ -23,7 +23,6 @@ import {
 } from '@/hooks';
 import { useUpdateTextRecord } from '@/hooks';
 import { useForm } from 'react-hook-form';
-import { useEffect } from 'react';
 import { useGetResolverAddress } from '@/hooks/api/vetDomains/useGetResolverAddress';
 
 export type CustomizationSummaryContentProps = {
@@ -106,6 +105,11 @@ export const CustomizationSummaryContent = ({
     });
 
     const onSubmit = async (data: FormValues) => {
+        if (upgradeRequired) {
+            openUpgradeSmartAccountModal();
+            return;
+        }
+
         try {
             const domain = account?.domain ?? '';
             const CHANGES_TO_TEXT_RECORDS = {
@@ -150,12 +154,6 @@ export const CustomizationSummaryContent = ({
             </VStack>
         );
     };
-
-    useEffect(() => {
-        if (upgradeRequired) {
-            openUpgradeSmartAccountModal();
-        }
-    }, [upgradeRequired, openUpgradeSmartAccountModal]);
 
     return (
         <Box as="form" onSubmit={handleSubmit(onSubmit)}>
@@ -205,7 +203,7 @@ export const CustomizationSummaryContent = ({
                     transactionPendingText={t('Saving changes...')}
                     txReceipt={txReceipt}
                     buttonText={t('Confirm')}
-                    isDisabled={isTransactionPending || upgradeRequired}
+                    isDisabled={isTransactionPending}
                 />
             </ModalFooter>
         </Box>

--- a/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
@@ -27,7 +27,7 @@ import { ExchangeWarningAlert } from '@/components';
 import { useTranslation } from 'react-i18next';
 import { useVeChainKitConfig } from '@/providers';
 import { useGetAvatar } from '@/hooks/api/vetDomains';
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { convertUriToUrl } from '@/utils';
 import { Token } from './SelectTokenContent';
 
@@ -147,6 +147,11 @@ export const SendTokenSummaryContent = ({
     };
 
     const handleSend = async () => {
+        if (upgradeRequired) {
+            openUpgradeSmartAccountModal();
+            return;
+        }
+
         try {
             if (selectedToken.symbol === 'VET') {
                 await transferVET();
@@ -163,12 +168,6 @@ export const SendTokenSummaryContent = ({
         transferVETWaitingForWalletConfirmation;
     const isSubmitting =
         isTxWaitingConfirmation || transferERC20Pending || transferVETPending;
-
-    useEffect(() => {
-        if (upgradeRequired) {
-            openUpgradeSmartAccountModal();
-        }
-    }, [upgradeRequired, openUpgradeSmartAccountModal]);
 
     return (
         <>
@@ -264,7 +263,7 @@ export const SendTokenSummaryContent = ({
                     transactionPendingText={t('Sending...')}
                     txReceipt={getTxReceipt()}
                     buttonText={t('Confirm')}
-                    isDisabled={isSubmitting || upgradeRequired}
+                    isDisabled={isSubmitting}
                 />
             </ModalFooter>
         </>

--- a/packages/vechain-kit/src/hooks/modals/index.ts
+++ b/packages/vechain-kit/src/hooks/modals/index.ts
@@ -13,3 +13,4 @@ export * from './useAccountCustomizationModal';
 export * from './useReceiveModal';
 export * from './useLoginModalContent';
 export * from './useUpgradeSmartAccountModal';
+export * from './useProfileModal';

--- a/packages/vechain-kit/src/hooks/modals/useProfileModal.tsx
+++ b/packages/vechain-kit/src/hooks/modals/useProfileModal.tsx
@@ -1,0 +1,25 @@
+import { useModal } from '@/providers/ModalProvider';
+import { ReactNode } from 'react';
+
+export const useProfileModal = () => {
+    const { openAccountModal, closeAccountModal, isAccountModalOpen } =
+        useModal();
+
+    const open = () => {
+        openAccountModal('profile');
+    };
+
+    const close = () => {
+        closeAccountModal();
+    };
+
+    return {
+        open,
+        close,
+        isOpen: isAccountModalOpen,
+    };
+};
+
+export const ProfileModalProvider = ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+);


### PR DESCRIPTION
### Description

- Fixed bug that was preventing the user to close the `UpgradeSmartAccountModal`
- Show a red dot in settings to make the user understand he has some action to complete
- Export `useProfileModal` so devs can open directly the profile content

Closes #(issue)

### Updated packages (if any):

-  [ ] next-template
-  [x ] homepage
-  [x ] vechain-kit
