### PR TITLE
Update deployment workflow

### DIFF
--- a/.github/workflows/deploy-cloudfront.yaml
+++ b/.github/workflows/deploy-cloudfront.yaml
@@ -1,5 +1,5 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy to GitHub Pages
+# Simple workflow for deploying static content to Cloudfront
+name: Deploy to Cloudfront
 
 on:
     # Runs on pushes targeting the default branch
@@ -9,20 +9,18 @@ on:
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets permissions of the GITHUB_TOKEN to allow deployment to Cloudfront
 permissions:
     contents: read
-    pages: write
     id-token: write
-    packages: write
 
 # Allow one concurrent deployment
 concurrency:
-    group: 'pages'
+    group: 'cloudfront-deploy'
     cancel-in-progress: true
 
 jobs:
-    build:
+    build-and-deploy:
         runs-on: ubuntu-latest
         env:
             BASE_PATH: ''
@@ -47,11 +45,6 @@ jobs:
                   chmod -c -R +rX "./examples/homepage/dist" | while read line; do
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                   done
-
-            - name: Upload artifact
-              uses: actions/upload-pages-artifact@v3
-              with:
-                  path: './examples/homepage/dist'
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -66,17 +66,3 @@ jobs:
             - name: Cloudfront Invalidation
               run: |
                   AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/' '/*'
-
-    deploy:
-        needs: build
-        permissions:
-            pages: write
-            id-token: write
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Deploy to GitHub Pages
-              id: deployment
-              uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Description

This PR updates the deployment workflow by only deploying to AWS and removing deployment to GitHub Pages.

Closes https://github.com/vechain/vechain-kit/issues/121

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [ ] vechain-kit
