### PR TITLE
Fix: Set Minimum Size for `AccountAvatar`

### DIFF
--- a/packages/vechain-kit/src/components/WalletButton/ConnectedWallet.tsx
+++ b/packages/vechain-kit/src/components/WalletButton/ConnectedWallet.tsx
@@ -22,7 +22,12 @@ export const ConnectedWallet = ({
             <HStack>
                 <AccountAvatar
                     wallet={account}
-                    props={{ width: 30, height: 30 }}
+                    props={{
+                        width: 30,
+                        height: 30,
+                        minWidth: 30,
+                        minHeight: 30,
+                    }}
                 />
                 {!isDesktop && <WalletDisplay variant={mobileVariant} />}
                 {isDesktop && <WalletDisplay variant={desktopVariant} />}


### PR DESCRIPTION
### Description

This PR ensures that the connected wallet's AccountAvatar does not shrink excessively when displaying vertical images. Previously, vertical images could cause the avatar to appear distorted or too small on certain screen sizes.

[Used 200x400 placeholder image](https://placehold.co/200x400) to test the fix.

## Before

https://github.com/user-attachments/assets/23012e3b-51ee-48ee-bd6a-37e04bd7cc18

## After

https://github.com/user-attachments/assets/145d718c-8d07-466a-bd70-e406d95a0355



Closes #172

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [x] vechain-kit


