### PR TITLE
Feat/refactor get avatar

### DIFF
--- a/packages/vechain-kit/src/components/AccountModal/Contents/Account/EmbeddedWalletContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Account/EmbeddedWalletContent.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { AccountModalContentTypes } from '../../Types';
 import { IoOpenOutline } from 'react-icons/io5';
 import { WalletSecuredBy } from '../ConnectionDetails/Components';
+import { useVeChainKitConfig } from '@/providers';
 
 type Props = {
     setCurrentContent: (content: AccountModalContentTypes) => void;
@@ -33,6 +34,7 @@ export const EmbeddedWalletContent = ({ setCurrentContent }: Props) => {
     const walletImage = getPicassoImage(connectedWallet?.address ?? '');
     const { getConnectionCache } = useCrossAppConnectionCache();
     const connectionCache = getConnectionCache();
+    const { darkMode: isDark } = useVeChainKitConfig();
 
     return (
         <ScrollToTopWrapper>
@@ -110,7 +112,11 @@ export const EmbeddedWalletContent = ({ setCurrentContent }: Props) => {
                                 <Link
                                     href="https://www.veworld.net/"
                                     isExternal
-                                    color="blackAlpha.600"
+                                    color={
+                                        isDark
+                                            ? 'whiteAlpha.600'
+                                            : 'blackAlpha.600'
+                                    }
                                     fontSize={'14px'}
                                     textDecoration={'underline'}
                                 >
@@ -125,7 +131,11 @@ export const EmbeddedWalletContent = ({ setCurrentContent }: Props) => {
                                 <Link
                                     href="https://docs.vechainkit.vechain.org/vechain-kit/embedded-wallets"
                                     isExternal
-                                    color="blackAlpha.600"
+                                    color={
+                                        isDark
+                                            ? 'whiteAlpha.600'
+                                            : 'blackAlpha.600'
+                                    }
                                     fontSize={'14px'}
                                     textDecoration={'underline'}
                                 >

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Assets/ManageCustomTokenContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Assets/ManageCustomTokenContent.tsx
@@ -211,7 +211,7 @@ export const ManageCustomTokenContent = ({
 
             <ModalFooter>
                 <Button
-                    variant="vechainKitSecondary"
+                    variant="vechainKitPrimary"
                     isDisabled={!isValid}
                     onClick={handleSubmit(onSubmit)}
                 >

--- a/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/Components/ExistingDomainsList.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/Components/ExistingDomainsList.tsx
@@ -18,11 +18,93 @@ import { useVeChainKitConfig } from '@/providers';
 import { useWallet } from '@/hooks';
 import { useWalletMetadata } from '@/hooks/api/wallet/useWalletMetadata';
 import { AccountAvatar } from '@/components/common';
+import { getPicassoImage } from '@/utils';
 
 type ExistingDomainsListProps = {
     domains: { name: string }[];
     onDomainSelect: (domain: string) => void;
     isLoading?: boolean;
+};
+
+const DomainListItem = ({
+    domain,
+    isCurrentDomain,
+    onSelect,
+}: {
+    domain: { name: string };
+    isCurrentDomain: boolean;
+    onSelect: (name: string) => void;
+}) => {
+    const { darkMode: isDark } = useVeChainKitConfig();
+    const { connection } = useWallet();
+    const { t } = useTranslation();
+    const metadata = useWalletMetadata(domain.name, connection.network);
+
+    return (
+        <ListItem
+            key={domain.name}
+            p={4}
+            bg={isDark ? '#1f1f1e' : 'white'}
+            borderRadius="xl"
+            cursor={isCurrentDomain ? 'default' : 'pointer'}
+            opacity={isCurrentDomain ? 0.7 : 1}
+            border={`1px solid ${isDark ? '#2d2d2d' : '#eaeaea'}`}
+            _hover={{
+                bg: isCurrentDomain
+                    ? isDark
+                        ? '#1f1f1e'
+                        : 'white'
+                    : isDark
+                    ? '#252525'
+                    : 'gray.50',
+                borderColor: isDark ? '#3d3d3d' : '#dedede',
+            }}
+            onClick={() => !isCurrentDomain && onSelect(domain.name)}
+            transition="all 0.2s"
+        >
+            <HStack spacing={3} align="center">
+                <AccountAvatar
+                    props={{
+                        width: '40px',
+                        height: '40px',
+                        src: metadata.image ?? getPicassoImage(domain.name),
+                        alt: domain.name,
+                    }}
+                />
+
+                <VStack align="start" spacing={0} flex={1}>
+                    <Text
+                        color={isDark ? 'whiteAlpha.900' : 'gray.700'}
+                        fontSize="md"
+                        fontWeight="500"
+                    >
+                        {domain.name}
+                    </Text>
+                    {isCurrentDomain && (
+                        <Text
+                            fontSize="sm"
+                            color={isDark ? 'whiteAlpha.600' : 'blackAlpha.600'}
+                        >
+                            {t('Current domain')}
+                        </Text>
+                    )}
+                </VStack>
+
+                {isCurrentDomain && (
+                    <Tag
+                        size="sm"
+                        bg={isDark ? '#ffffff0a' : 'whiteAlpha.100'}
+                        color={isDark ? 'whiteAlpha.900' : 'blackAlpha.600'}
+                        px={3}
+                        py={1}
+                        borderRadius="full"
+                    >
+                        {t('Current')}
+                    </Tag>
+                )}
+            </HStack>
+        </ListItem>
+    );
 };
 
 export const ExistingDomainsList = ({
@@ -32,7 +114,7 @@ export const ExistingDomainsList = ({
 }: ExistingDomainsListProps) => {
     const { t } = useTranslation();
     const { darkMode: isDark } = useVeChainKitConfig();
-    const { account, connection } = useWallet();
+    const { account } = useWallet();
 
     // avoid flickering after loading by returning null, so if no domains are found, it will not show the accordion
     if (domains.length === 0 || isLoading) {
@@ -71,112 +153,16 @@ export const ExistingDomainsList = ({
                         </AccordionButton>
                         <AccordionPanel pb={4} pt={2}>
                             <List spacing={2}>
-                                {domains.map((domain) => {
-                                    const isCurrentDomain =
-                                        domain.name === account?.domain;
-                                    const metadata = useWalletMetadata(
-                                        domain.name,
-                                        connection.network,
-                                    );
-                                    return (
-                                        <ListItem
-                                            key={domain.name}
-                                            p={4}
-                                            bg={isDark ? '#1f1f1e' : 'white'}
-                                            borderRadius="xl"
-                                            cursor={
-                                                isCurrentDomain
-                                                    ? 'default'
-                                                    : 'pointer'
-                                            }
-                                            opacity={isCurrentDomain ? 0.7 : 1}
-                                            border={`1px solid ${
-                                                isDark ? '#2d2d2d' : '#eaeaea'
-                                            }`}
-                                            _hover={{
-                                                bg: isCurrentDomain
-                                                    ? isDark
-                                                        ? '#1f1f1e'
-                                                        : 'white'
-                                                    : isDark
-                                                    ? '#252525'
-                                                    : 'gray.50',
-                                                borderColor: isDark
-                                                    ? '#3d3d3d'
-                                                    : '#dedede',
-                                            }}
-                                            onClick={() =>
-                                                !isCurrentDomain &&
-                                                onDomainSelect(domain.name)
-                                            }
-                                            transition="all 0.2s"
-                                        >
-                                            <HStack spacing={3} align="center">
-                                                <AccountAvatar
-                                                    props={{
-                                                        width: '40px',
-                                                        height: '40px',
-                                                        src: metadata.image,
-                                                        alt: domain.name,
-                                                    }}
-                                                />
-
-                                                <VStack
-                                                    align="start"
-                                                    spacing={0}
-                                                    flex={1}
-                                                >
-                                                    <Text
-                                                        color={
-                                                            isDark
-                                                                ? 'whiteAlpha.900'
-                                                                : 'gray.700'
-                                                        }
-                                                        fontSize="md"
-                                                        fontWeight="500"
-                                                    >
-                                                        {domain.name}
-                                                    </Text>
-                                                    {isCurrentDomain && (
-                                                        <Text
-                                                            fontSize="sm"
-                                                            color={
-                                                                isDark
-                                                                    ? 'whiteAlpha.600'
-                                                                    : 'blackAlpha.600'
-                                                            }
-                                                        >
-                                                            {t(
-                                                                'Current domain',
-                                                            )}
-                                                        </Text>
-                                                    )}
-                                                </VStack>
-
-                                                {isCurrentDomain && (
-                                                    <Tag
-                                                        size="sm"
-                                                        bg={
-                                                            isDark
-                                                                ? '#ffffff0a'
-                                                                : 'whiteAlpha.100'
-                                                        }
-                                                        color={
-                                                            isDark
-                                                                ? 'whiteAlpha.900'
-                                                                : 'blackAlpha.600'
-                                                        }
-                                                        px={3}
-                                                        py={1}
-                                                        borderRadius="full"
-                                                    >
-                                                        {t('Current')}
-                                                    </Tag>
-                                                )}
-                                            </HStack>
-                                        </ListItem>
-                                    );
-                                })}
+                                {domains.map((domain) => (
+                                    <DomainListItem
+                                        key={domain.name}
+                                        domain={domain}
+                                        isCurrentDomain={
+                                            domain.name === account?.domain
+                                        }
+                                        onSelect={onDomainSelect}
+                                    />
+                                ))}
                             </List>
                         </AccordionPanel>
                     </>

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationContent.tsx
@@ -108,7 +108,7 @@ export const CustomizationContent = ({
                 metadata.avatar ? metadata.avatar.replace('ipfs://', '') : null,
             );
             setPreviewImageUrl(
-                convertUriToUrl(metadata.avatar ?? '', network.type) || null,
+                convertUriToUrl(metadata.avatar ?? '', network.type),
             );
         }
     }, [account?.metadata, network.type]);

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
@@ -86,6 +86,7 @@ export const CustomizationSummaryContent = ({
         isTransactionPending,
     } = useUpdateTextRecord({
         resolverAddress, // Pass the pre-fetched resolver address
+        signerAccountAddress: account?.address ?? '',
         onSuccess: async () => {
             refreshMetadata();
             setCurrentContent({

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
@@ -57,6 +57,7 @@ export const CustomizationSummaryContent = ({
     const { account, connectedWallet } = useWallet();
     const { refresh: refreshMetadata } = useRefreshMetadata(
         account?.domain ?? '',
+        account?.address ?? '',
     );
     const { data: upgradeRequired } = useUpgradeRequired(
         account?.address ?? '',

--- a/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenContent.tsx
@@ -89,11 +89,8 @@ export const SendTokenContent = ({
     // Watch form values
     const { toAddressOrDomain } = watch();
 
-    const {
-        domain: resolvedDomain,
-        address: resolvedAddress,
-        isLoading: isLoadingDomain,
-    } = useVechainDomain({ addressOrDomain: toAddressOrDomain });
+    const { domain: resolvedDomain, address: resolvedAddress } =
+        useVechainDomain({ addressOrDomain: toAddressOrDomain });
 
     const handleSetMaxAmount = () => {
         if (selectedToken) {
@@ -426,7 +423,7 @@ export const SendTokenContent = ({
             <ModalFooter>
                 <Button
                     variant="vechainKitPrimary"
-                    isDisabled={!selectedToken || !isValid || isLoadingDomain}
+                    isDisabled={!selectedToken || !isValid}
                     onClick={handleSubmit(onSubmit)}
                 >
                     {selectedToken ? t('Send') : t('Select Token')}

--- a/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
@@ -28,7 +28,6 @@ import { useTranslation } from 'react-i18next';
 import { useVeChainKitConfig } from '@/providers';
 import { useGetAvatar } from '@/hooks/api/vetDomains';
 import { useMemo } from 'react';
-import { convertUriToUrl } from '@/utils';
 import { Token } from './SelectTokenContent';
 
 const compactFormatter = new Intl.NumberFormat('en-US', {
@@ -64,7 +63,7 @@ export const SendTokenSummaryContent = ({
 }: SendTokenSummaryContentProps) => {
     const { t } = useTranslation();
     const { account, connection, connectedWallet } = useWallet();
-    const { data: avatar } = useGetAvatar(resolvedDomain);
+    const { data: avatar } = useGetAvatar(resolvedDomain ?? '');
     const { network } = useVeChainKitConfig();
     const { data: upgradeRequired } = useUpgradeRequired(
         account?.address ?? '',
@@ -77,7 +76,7 @@ export const SendTokenSummaryContent = ({
     // Get the final image URL
     const toImageSrc = useMemo(() => {
         if (avatar) {
-            return convertUriToUrl(avatar, network.type);
+            return avatar;
         }
         return getPicassoImage(resolvedAddress || toAddressOrDomain);
     }, [avatar, network.type, resolvedAddress, toAddressOrDomain]);

--- a/packages/vechain-kit/src/components/ProfileCard/ProfileCard.tsx
+++ b/packages/vechain-kit/src/components/ProfileCard/ProfileCard.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react';
 import { AccountAvatar, AddressDisplay } from '@/components/common';
 import {
-    useGetAvatar,
+    useGetAvatarOfAddress,
     useGetTextRecords,
     useVechainDomain,
     useWallet,
@@ -58,9 +58,7 @@ export const ProfileCard = ({
     const { account } = useWallet();
 
     const activeAccountDomain = useVechainDomain(address);
-    const activeAccountAvatar = useGetAvatar(
-        activeAccountDomain?.data?.domain ?? '',
-    );
+    const activeAccountAvatar = useGetAvatarOfAddress(address);
     const activeAccountTextRecords = useGetTextRecords(
         activeAccountDomain?.data?.domain,
     );
@@ -97,9 +95,7 @@ export const ProfileCard = ({
                     wallet={{
                         address,
                         domain: activeAccountDomain?.data?.domain,
-                        image:
-                            activeAccountAvatar?.data ??
-                            getPicassoImage(address),
+                        image: activeAccountAvatar.data,
                         isLoadingMetadata:
                             activeAccountAvatar?.isLoading ||
                             activeAccountDomain?.isLoading ||
@@ -178,9 +174,7 @@ export const ProfileCard = ({
                         wallet={{
                             address,
                             domain: activeAccountDomain?.data?.domain,
-                            image:
-                                activeAccountAvatar?.data ??
-                                getPicassoImage(address),
+                            image: activeAccountAvatar.data,
                             isLoadingMetadata:
                                 activeAccountAvatar?.isLoading ||
                                 activeAccountDomain?.isLoading ||

--- a/packages/vechain-kit/src/components/ProfileCard/ProfileCard.tsx
+++ b/packages/vechain-kit/src/components/ProfileCard/ProfileCard.tsx
@@ -21,12 +21,11 @@ import {
     useVechainDomain,
     useWallet,
 } from '@/hooks';
-import { useVeChainKitConfig } from '@/providers';
 import { FaEdit, FaEnvelope, FaGlobe } from 'react-icons/fa';
 import { RiLogoutBoxLine } from 'react-icons/ri';
 import { FaXTwitter } from 'react-icons/fa6';
 import { useTranslation } from 'react-i18next';
-import { convertUriToUrl, getPicassoImage } from '@/utils';
+import { getPicassoImage } from '@/utils';
 
 export type ProfileCardProps = {
     address: string;
@@ -56,12 +55,12 @@ export const ProfileCard = ({
     style,
 }: ProfileCardProps) => {
     const { t } = useTranslation();
-
-    const { network } = useVeChainKitConfig();
     const { account } = useWallet();
 
     const activeAccountDomain = useVechainDomain(address);
-    const activeAccountAvatar = useGetAvatar(activeAccountDomain?.data?.domain);
+    const activeAccountAvatar = useGetAvatar(
+        activeAccountDomain?.data?.domain ?? '',
+    );
     const activeAccountTextRecords = useGetTextRecords(
         activeAccountDomain?.data?.domain,
     );
@@ -99,10 +98,8 @@ export const ProfileCard = ({
                         address,
                         domain: activeAccountDomain?.data?.domain,
                         image:
-                            convertUriToUrl(
-                                activeAccountAvatar?.data ?? '',
-                                network.type,
-                            ) ?? getPicassoImage(address),
+                            activeAccountAvatar?.data ??
+                            getPicassoImage(address),
                         isLoadingMetadata:
                             activeAccountAvatar?.isLoading ||
                             activeAccountDomain?.isLoading ||
@@ -182,10 +179,8 @@ export const ProfileCard = ({
                             address,
                             domain: activeAccountDomain?.data?.domain,
                             image:
-                                convertUriToUrl(
-                                    activeAccountAvatar?.data ?? '',
-                                    network.type,
-                                ) ?? getPicassoImage(address),
+                                activeAccountAvatar?.data ??
+                                getPicassoImage(address),
                             isLoadingMetadata:
                                 activeAccountAvatar?.isLoading ||
                                 activeAccountDomain?.isLoading ||

--- a/packages/vechain-kit/src/components/common/AccountAvatar.tsx
+++ b/packages/vechain-kit/src/components/common/AccountAvatar.tsx
@@ -13,8 +13,8 @@ export const AccountAvatar = ({ wallet, props }: AccountAvatarProps) => {
 
     return (
         <Image
-            src={props?.src ?? wallet?.image}
-            alt={props?.alt ?? wallet?.domain}
+            src={props?.src || wallet?.image}
+            alt={props?.alt || wallet?.domain}
             objectFit="cover"
             rounded="full"
             {...props}

--- a/packages/vechain-kit/src/components/common/AccountAvatar.tsx
+++ b/packages/vechain-kit/src/components/common/AccountAvatar.tsx
@@ -1,6 +1,5 @@
 import { Wallet } from '@/types';
 import { Image, ImageProps, Spinner } from '@chakra-ui/react';
-import { getPicassoImage } from '@/utils';
 
 type AccountAvatarProps = {
     wallet?: Wallet;
@@ -12,14 +11,9 @@ export const AccountAvatar = ({ wallet, props }: AccountAvatarProps) => {
         return <Spinner size="sm" />;
     }
 
-    const fallbackImage = wallet?.address
-        ? getPicassoImage(wallet.address)
-        : undefined;
-
     return (
         <Image
             src={props?.src ?? wallet?.image}
-            fallbackSrc={fallbackImage}
             alt={props?.alt ?? wallet?.domain}
             objectFit="cover"
             rounded="full"

--- a/packages/vechain-kit/src/hooks/api/vetDomains/index.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/index.ts
@@ -7,3 +7,4 @@ export * from './useGetAvatar';
 export * from './useGetTextRecords';
 export * from './useUpdateTextRecord';
 export * from './useGetResolverAddress';
+export * from './useGetAvatarOfAddress';

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatar.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatar.ts
@@ -1,12 +1,24 @@
 import { useQuery } from '@tanstack/react-query';
 import { useVeChainKitConfig } from '@/providers';
-import { Interface, namehash } from 'ethers';
+import {
+    Interface,
+    namehash,
+    toUtf8String,
+    zeroPadValue,
+    toBeHex,
+} from 'ethers';
 import { NETWORK_TYPE } from '@/config/network';
 import { getConfig } from '@/config';
+import { convertUriToUrl } from '@/utils/uri';
 
 const nameInterface = new Interface([
     'function resolver(bytes32 node) returns (address resolverAddress)',
     'function text(bytes32 node, string key) returns (string avatar)',
+]);
+
+const erc721Interface = new Interface([
+    'function tokenURI(uint256 tokenId) view returns (string)',
+    'function uri(uint256 id) view returns (string)',
 ]);
 
 /**
@@ -105,18 +117,123 @@ export const getAvatarQueryKey = (name: string) => [
     name,
 ];
 
+async function parseAvatarRecord(
+    record: string,
+    networkType: NETWORK_TYPE,
+    nodeUrl: string,
+): Promise<string | null> {
+    try {
+        // Use the existing URI converter for direct URL handling
+        if (
+            record.startsWith('http') ||
+            record.startsWith('ipfs://') ||
+            record.startsWith('ar://')
+        ) {
+            return convertUriToUrl(record, networkType) || null;
+        }
+
+        // Handle NFT avatar (ENS-12)
+        const match = record.match(
+            /eip155:(\d+)\/(?:erc721|erc1155):([^/]+)\/(\d+)/,
+        );
+        if (match) {
+            const [, chainId, contractAddress, tokenId] = match;
+            const isErc1155 = record.includes('erc1155');
+
+            if (!chainId || !contractAddress || tokenId === undefined) {
+                return null;
+            }
+
+            // ... rest of NFT handling logic ...
+            const clauses = [
+                {
+                    to: contractAddress,
+                    data: erc721Interface.encodeFunctionData(
+                        isErc1155 ? 'uri' : 'tokenURI',
+                        [BigInt(tokenId)],
+                    ),
+                },
+            ];
+
+            const [{ data, reverted }] = await fetch(`${nodeUrl}/accounts/*`, {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                },
+                body: JSON.stringify({ clauses }),
+            }).then((res) => res.json());
+
+            if (reverted) {
+                console.error('Failed to fetch tokenURI');
+                return null;
+            }
+
+            let tokenUri = '';
+            try {
+                tokenUri = erc721Interface.decodeFunctionResult(
+                    isErc1155 ? 'uri' : 'tokenURI',
+                    data,
+                )[0];
+            } catch (e) {
+                console.error('Failed to decode avatar data:', e);
+                tokenUri = toUtf8String(data);
+            }
+
+            // Use the existing URI converter
+            tokenUri = convertUriToUrl(tokenUri, networkType) || tokenUri;
+
+            if (isErc1155) {
+                tokenUri = tokenUri.replace(
+                    '{id}',
+                    zeroPadValue(toBeHex(BigInt(tokenId)), 32).slice(2),
+                );
+            }
+
+            const metadataResponse = await fetch(tokenUri);
+            if (!metadataResponse.ok) {
+                console.error('Failed to fetch metadata');
+                return null;
+            }
+
+            const metadata = await metadataResponse.json();
+            const imageUrl =
+                metadata.image || metadata.image_url || metadata.image_data;
+
+            if (!imageUrl) {
+                console.error('No image URL in metadata');
+                return null;
+            }
+
+            // Use the existing URI converter for the final image URL
+            return convertUriToUrl(imageUrl, networkType) || imageUrl;
+        }
+
+        return null;
+    } catch (error) {
+        console.error('Error parsing avatar record:', error);
+        return null;
+    }
+}
+
 /**
  * Hook to fetch the avatar URL for a VET domain name
  * @param name - The VET domain name
  * @returns The resolved avatar URL
  */
-export const useGetAvatar = (name?: string) => {
+export const useGetAvatar = (name: string) => {
     const { network } = useVeChainKitConfig();
     const nodeUrl = network.nodeUrl ?? getConfig(network.type).nodeUrl;
 
     const avatarQuery = useQuery({
         queryKey: getAvatarQueryKey(name ?? ''),
-        queryFn: () => getAvatar(network.type, nodeUrl, name!),
+        queryFn: async () => {
+            if (!name) return null;
+
+            const avatarRecord = await getAvatar(network.type, nodeUrl, name);
+            if (!avatarRecord) return null;
+
+            return parseAvatarRecord(avatarRecord, network.type, nodeUrl);
+        },
         enabled: !!name && !!nodeUrl && !!network.type,
         retry: 3,
         retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatar.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatar.ts
@@ -235,8 +235,7 @@ export const useGetAvatar = (name: string) => {
             return parseAvatarRecord(avatarRecord, network.type, nodeUrl);
         },
         enabled: !!name && !!nodeUrl && !!network.type,
-        retry: 3,
-        retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+        // Use the same caching strategy as the avatar query
         staleTime: 5 * 60 * 1000, // 5 minutes
     });
 

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarOfAddress.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarOfAddress.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { useGetAvatar } from './useGetAvatar';
+import { getPicassoImage } from '@/utils';
+import { useVechainDomain } from './useVechainDomain';
+
+export const getAvatarOfAddressQueryKey = (address?: string) => [
+    'VECHAIN_KIT',
+    'VET_DOMAINS',
+    'AVATAR_OF_ADDRESS',
+    address,
+];
+
+/**
+ * Hook to fetch the avatar for an address by first getting their domains
+ * and then fetching the avatar for the first domain found
+ * @param address The owner's address
+ * @returns The avatar URL for the address's primary domain
+ */
+export const useGetAvatarOfAddress = (address?: string) => {
+    // First, get all domains for this address
+    const domainsQuery = useVechainDomain(address);
+
+    // Then, get the avatar for the first domain
+    const primaryDomain = domainsQuery.data?.domain;
+    const avatarQuery = useGetAvatar(primaryDomain ?? '');
+
+    return useQuery({
+        queryKey: getAvatarOfAddressQueryKey(address),
+        queryFn: async () => {
+            if (!address) return getPicassoImage(address ?? '');
+
+            // Wait for domains to be fetched
+            const domains = await domainsQuery.refetch();
+            if (!domains.data?.domain) return getPicassoImage(address);
+
+            return avatarQuery.data;
+        },
+        enabled:
+            !!address &&
+            domainsQuery.isSuccess &&
+            !!primaryDomain &&
+            avatarQuery.isSuccess,
+        // Use the same caching strategy as the avatar query
+        staleTime: 5 * 60 * 1000, // 5 minutes
+    });
+};

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarOfAddress.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarOfAddress.ts
@@ -20,7 +20,7 @@ export const useGetAvatarOfAddress = (address?: string) => {
     // First, get all domains for this address
     const domainsQuery = useVechainDomain(address);
 
-    // Then, get the avatar for the first domain
+    // Then, get the avatar for the first domain, but only if we have one
     const primaryDomain = domainsQuery.data?.domain;
     const avatarQuery = useGetAvatar(primaryDomain ?? '');
 
@@ -33,11 +33,16 @@ export const useGetAvatarOfAddress = (address?: string) => {
             const domains = await domainsQuery.refetch();
             if (!domains.data?.domain) return getPicassoImage(address);
 
-            if (avatarQuery.data) return avatarQuery.data;
+            // Only try to get the avatar if we have a valid domain
+            if (domains.data.domain && avatarQuery.data)
+                return avatarQuery.data;
 
             return getPicassoImage(address);
         },
-        enabled: !!address && domainsQuery.isSuccess && avatarQuery.isSuccess,
+        enabled:
+            !!address &&
+            domainsQuery.isSuccess &&
+            (primaryDomain ? avatarQuery.isSuccess : true),
         // Use the same caching strategy as the avatar query
         staleTime: 5 * 60 * 1000, // 5 minutes
     });

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarOfAddress.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarOfAddress.ts
@@ -33,13 +33,11 @@ export const useGetAvatarOfAddress = (address?: string) => {
             const domains = await domainsQuery.refetch();
             if (!domains.data?.domain) return getPicassoImage(address);
 
-            return avatarQuery.data;
+            if (avatarQuery.data) return avatarQuery.data;
+
+            return getPicassoImage(address);
         },
-        enabled:
-            !!address &&
-            domainsQuery.isSuccess &&
-            !!primaryDomain &&
-            avatarQuery.isSuccess,
+        enabled: !!address && domainsQuery.isSuccess && avatarQuery.isSuccess,
         // Use the same caching strategy as the avatar query
         staleTime: 5 * 60 * 1000, // 5 minutes
     });

--- a/packages/vechain-kit/src/hooks/api/wallet/useRefreshMetadata.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useRefreshMetadata.ts
@@ -1,8 +1,12 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { getAvatarQueryKey, getTextRecordsQueryKey } from '../vetDomains';
+import {
+    getAvatarOfAddressQueryKey,
+    getAvatarQueryKey,
+    getTextRecordsQueryKey,
+} from '../vetDomains';
 import { useVeChainKitConfig } from '@/providers';
 
-export const useRefreshMetadata = (domain: string) => {
+export const useRefreshMetadata = (domain: string, address: string) => {
     const queryClient = useQueryClient();
     const { network } = useVeChainKitConfig();
 
@@ -21,6 +25,14 @@ export const useRefreshMetadata = (domain: string) => {
 
         await queryClient.refetchQueries({
             queryKey: getTextRecordsQueryKey(domain, network.type),
+        });
+
+        await queryClient.invalidateQueries({
+            queryKey: getAvatarOfAddressQueryKey(address),
+        });
+
+        await queryClient.refetchQueries({
+            queryKey: getAvatarOfAddressQueryKey(address),
         });
     };
 

--- a/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
@@ -10,17 +10,12 @@ import {
     useGetChainId,
     useGetNodeUrl,
     useSmartAccountVersion,
-    useGetAvatar,
     useGetTextRecords,
     useVechainDomain,
     useDAppKitWallet,
+    useGetAvatarOfAddress,
 } from '@/hooks';
-import {
-    compareAddresses,
-    convertUriToUrl,
-    getPicassoImage,
-    VECHAIN_PRIVY_APP_ID,
-} from '@/utils';
+import { compareAddresses, VECHAIN_PRIVY_APP_ID } from '@/utils';
 import { ConnectionSource, SmartAccount, Wallet } from '@/types';
 import { useSmartAccount } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
@@ -170,7 +165,7 @@ export const useWallet = (): UseWalletReturnType => {
         : smartAccount?.address;
 
     const activeAccountDomain = useVechainDomain(activeAddress ?? '');
-    const activeAccountAvatar = useGetAvatar(activeAccountDomain?.data?.domain);
+    const activeAccountAvatar = useGetAvatarOfAddress(activeAddress ?? '');
     const activeAccountTextRecords = useGetTextRecords(
         activeAccountDomain?.data?.domain,
     );
@@ -189,9 +184,7 @@ export const useWallet = (): UseWalletReturnType => {
         ? {
               address: activeAddress,
               domain: activeAccountDomain?.data?.domain,
-              image: activeAccountAvatar.data
-                  ? convertUriToUrl(activeAccountAvatar.data, network.type)
-                  : getPicassoImage(activeAddress ?? ''),
+              image: activeAccountAvatar.data ?? undefined,
               isLoadingMetadata:
                   activeAccountAvatar?.isLoading ||
                   activeAccountDomain?.isLoading ||
@@ -204,7 +197,7 @@ export const useWallet = (): UseWalletReturnType => {
         ? {
               address: connectedWalletAddress,
               domain: connectedMetadata.domain,
-              image: connectedMetadata.image,
+              image: connectedMetadata.image ?? undefined,
               isLoadingMetadata: connectedMetadata.isLoading,
               metadata: connectedMetadata.records,
           }
@@ -256,7 +249,7 @@ export const useWallet = (): UseWalletReturnType => {
         smartAccount: {
             address: smartAccount?.address ?? '',
             domain: smartAccountMetadata.domain,
-            image: smartAccountMetadata.image,
+            image: smartAccountMetadata.image ?? undefined,
             isDeployed: smartAccount?.isDeployed ?? false,
             isActive: hasActiveSmartAccount,
             version: smartAccountVersion ?? null,

--- a/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
@@ -15,7 +15,11 @@ import {
     useDAppKitWallet,
     useGetAvatarOfAddress,
 } from '@/hooks';
-import { compareAddresses, VECHAIN_PRIVY_APP_ID } from '@/utils';
+import {
+    compareAddresses,
+    getPicassoImage,
+    VECHAIN_PRIVY_APP_ID,
+} from '@/utils';
 import { ConnectionSource, SmartAccount, Wallet } from '@/types';
 import { useSmartAccount } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
@@ -184,7 +188,7 @@ export const useWallet = (): UseWalletReturnType => {
         ? {
               address: activeAddress,
               domain: activeAccountDomain?.data?.domain,
-              image: activeAccountAvatar.data ?? undefined,
+              image: activeAccountAvatar.data,
               isLoadingMetadata:
                   activeAccountAvatar?.isLoading ||
                   activeAccountDomain?.isLoading ||
@@ -197,7 +201,7 @@ export const useWallet = (): UseWalletReturnType => {
         ? {
               address: connectedWalletAddress,
               domain: connectedMetadata.domain,
-              image: connectedMetadata.image ?? undefined,
+              image: connectedMetadata.image,
               isLoadingMetadata: connectedMetadata.isLoading,
               metadata: connectedMetadata.records,
           }
@@ -249,7 +253,7 @@ export const useWallet = (): UseWalletReturnType => {
         smartAccount: {
             address: smartAccount?.address ?? '',
             domain: smartAccountMetadata.domain,
-            image: smartAccountMetadata.image ?? undefined,
+            image: smartAccountMetadata.image,
             isDeployed: smartAccount?.isDeployed ?? false,
             isActive: hasActiveSmartAccount,
             version: smartAccountVersion ?? null,

--- a/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useWallet.ts
@@ -15,11 +15,7 @@ import {
     useDAppKitWallet,
     useGetAvatarOfAddress,
 } from '@/hooks';
-import {
-    compareAddresses,
-    getPicassoImage,
-    VECHAIN_PRIVY_APP_ID,
-} from '@/utils';
+import { compareAddresses, VECHAIN_PRIVY_APP_ID } from '@/utils';
 import { ConnectionSource, SmartAccount, Wallet } from '@/types';
 import { useSmartAccount } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';

--- a/packages/vechain-kit/src/hooks/api/wallet/useWalletMetadata.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useWalletMetadata.ts
@@ -1,10 +1,10 @@
 import { NETWORK_TYPE } from '@/config/network';
 import {
-    useGetAvatar,
     useVechainDomain,
     useGetTextRecords,
+    useGetAvatarOfAddress,
 } from '../vetDomains';
-import { convertUriToUrl, getPicassoImage } from '@/utils';
+import { convertUriToUrl } from '@/utils';
 import { ENSRecords } from '@/types';
 
 export const useWalletMetadata = (
@@ -13,20 +13,17 @@ export const useWalletMetadata = (
 ) => {
     const { data: domain, isLoading: isLoadingVechainDomain } =
         useVechainDomain(address ?? '');
-    const { data: avatar, isLoading: isLoadingMetadata } = useGetAvatar(
-        domain?.domain,
-    );
+    const { data: avatar, isLoading: isLoadingMetadata } =
+        useGetAvatarOfAddress(address ?? '');
     const { data: textRecords, isLoading: isLoadingRecords } =
-        useGetTextRecords(domain?.domain);
-
-    const avatarUrl = avatar ? convertUriToUrl(avatar, networkType) : null;
+        useGetTextRecords(domain?.domain ?? '');
     const headerUrl = textRecords?.header
         ? convertUriToUrl(textRecords.header, networkType)
         : null;
 
     return {
         domain: domain?.domain,
-        image: avatarUrl ?? getPicassoImage(address ?? ''),
+        image: avatar,
         records: {
             ...textRecords,
             header: headerUrl,

--- a/packages/vechain-kit/src/utils/uri.ts
+++ b/packages/vechain-kit/src/utils/uri.ts
@@ -14,7 +14,7 @@ export const convertUriToUrl = (uri: string, networkType: NETWORK_TYPE) => {
     if (uri.startsWith('data:')) return uri;
 
     const splitUri = uri?.split('://');
-    if (splitUri.length !== 2) return;
+    if (splitUri.length !== 2) return null;
     // if (splitUri.length !== 2) throw new Error(`Invalid URI ${uri}`);
 
     const protocol = splitUri?.[0]?.trim();


### PR DESCRIPTION
### Description

- `useGetAvatar(domainName)` will now parse eip155 standard avatar record (getting the correct nft image). This hook will also return now directly the url of the image, removing the needs for developers to convert the uri to url separatly. The response can be `null` if the domain name does not exist or there is no avatar attached to this domain.
- I created a new hook called `useGetAvatarOfAddress(userAddress)`. This hook will check if the address has any primary domain name set, and if yes it will fetch and return the avatar url (again, no need to manaully convert uri to url, the hook does it). If there is no domain name attached to it or if there is no avatar attached to the domain it will return the picasso image.

Closes #167 
Closes #177 

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [x] vechain-kit
