### PR TITLE
Fix: Add fallback for `getAvatar` fetch

### DIFF
--- a/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarLegacy.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useGetAvatarLegacy.ts
@@ -125,7 +125,7 @@ export const getAvatarLegacy = async (
             return null;
         }
     } catch (error) {
-        console.error('Error fetching avatar:', error);
+        console.error('Error fetching avatar using legacy API:', error);
         throw error;
     }
 };


### PR DESCRIPTION
### Description

Sometimes, when using the testnet version of VET Domains to fetch a user's avatar, a CORS error may occur due to restrictions on allowed origins in the API. To ensure developers and users can still test avatar resolution reliably, I’ve implemented a fallback mechanism.

The `getAvatar` logic now follows this flow:

1. **Primary**: Attempt to fetch the avatar from VET Domains.  
2. **Fallback 1**: If the VET Domains request fails or returns `null`, try fetching the avatar directly from the user's `avatar` text record.  
3. **Fallback 2**: If both the above attempts fail, fall back to a default Picasso avatar.

This ensures that as long as at least one method resolves the avatar successfully, the user experience remains uninterrupted , even in environments where CORS issues may occur with the testnet API.


https://github.com/user-attachments/assets/65fe0261-439c-475b-8b67-866b9f1c930e


Closes #110 

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [x] vechain-kit
