### PR TITLE
centralise error handling for user rejections

### DIFF
--- a/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
@@ -22,7 +22,7 @@ import {
     useWallet,
 } from '@/hooks';
 import { Analytics } from '@/utils/mixpanelClientInstance';
-
+import { isRejectionError } from '@/utils/StringUtils';
 export type ChooseNameSummaryContentProps = {
     setCurrentContent: React.Dispatch<
         React.SetStateAction<AccountModalContentTypes>
@@ -53,11 +53,7 @@ export const ChooseNameSummaryContent = ({
         useUpgradeSmartAccountModal();
 
     const handleError = (error: string) => {
-        if (
-            error.toLowerCase().includes('rejected') ||
-            error.toLowerCase().includes('cancelled') ||
-            error.toLowerCase().includes('user denied')
-        ) {
+        if (isRejectionError(error)) {
             Analytics.nameSelection.dropOff('confirmation', {
                 isError: true,
                 name,

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
@@ -25,6 +25,7 @@ import { useUpdateTextRecord } from '@/hooks';
 import { useForm } from 'react-hook-form';
 import { useGetResolverAddress } from '@/hooks/api/vetDomains/useGetResolverAddress';
 import { Analytics } from '@/utils/mixpanelClientInstance';
+import { isRejectionError } from '@/utils/StringUtils';
 
 export type CustomizationSummaryContentProps = {
     setCurrentContent: React.Dispatch<
@@ -106,15 +107,11 @@ export const CustomizationSummaryContent = ({
             });
         },
         onError: (error) => {
-            if (
-                error?.message?.toLowerCase().includes('user denied') ||
-                error?.message?.toLowerCase().includes('rejected') ||
-                error?.message?.toLowerCase().includes('cancelled')
-            ) {
+            if (error && isRejectionError(error?.message ?? '')) {
                 Analytics.customization.dropOff({
                     stage: 'confirmation',
                     reason: 'wallet_rejected',
-                    error: error.message,
+                    error: error?.message,
                 });
             } else {
                 Analytics.customization.failed(

--- a/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
@@ -30,6 +30,7 @@ import { useGetAvatarOfAddress } from '@/hooks/api/vetDomains';
 import { useMemo } from 'react';
 import { Token } from './SelectTokenContent';
 import { Analytics } from '@/utils/mixpanelClientInstance';
+import { isRejectionError } from '@/utils/StringUtils';
 
 const compactFormatter = new Intl.NumberFormat('en-US', {
     notation: 'compact',
@@ -220,11 +221,7 @@ export const SendTokenSummaryContent = ({
     };
 
     const handleError = (error: string) => {
-        if (
-            error.toLowerCase().includes('rejected') ||
-            error.toLowerCase().includes('cancelled') ||
-            error.toLowerCase().includes('user denied')
-        ) {
+        if (error && isRejectionError(error)) {
             Analytics.send.flow('review', {
                 tokenSymbol: selectedToken.symbol,
                 amount,

--- a/packages/vechain-kit/src/components/ConnectModal/Components/DappKitButton.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/DappKitButton.tsx
@@ -8,6 +8,7 @@ import { Analytics } from '@/utils/mixpanelClientInstance';
 import { VeLoginMethod, DappKitSource } from '@/types/mixPanel';
 import { useEffect } from 'react';
 import { useWallet as useDappKitWallet } from '@vechain/dapp-kit-react';
+import { isRejectionError } from '@/utils/StringUtils';
 
 type Props = {
     isDark: boolean;
@@ -48,10 +49,7 @@ export const DappKitButton = ({ isDark, gridColumn = 2 }: Props) => {
                             },
                         );
                     }
-                    if (
-                        errorMsg.includes('rejected') ||
-                        errorMsg.includes('denied')
-                    ) {
+                    if (errorMsg && isRejectionError(errorMsg)) {
                         return Analytics.auth.dropOff('dappkit-view', {
                             ...(source && { source }),
                         });

--- a/packages/vechain-kit/src/components/EcosystemModal/EcosystemContent.tsx
+++ b/packages/vechain-kit/src/components/EcosystemModal/EcosystemContent.tsx
@@ -21,7 +21,7 @@ import { PrivyAppInfo } from '@/types';
 import { useVeChainKitConfig } from '@/providers';
 import { Analytics } from '@/utils/mixpanelClientInstance';
 import { VeLoginMethod } from '@/types/mixPanel';
-
+import { isRejectionError } from '@/utils/StringUtils';
 type Props = {
     onClose: () => void;
     appsInfo: PrivyAppInfo[];
@@ -71,10 +71,7 @@ export const EcosystemContent = ({ onClose, appsInfo, isLoading }: Props) => {
                 const errorMsg = (error as { message?: string })?.message;
 
                 // Handle user rejection or other errors
-                if (
-                    errorMsg?.includes('rejected') ||
-                    errorMsg?.includes('closed')
-                ) {
+                if (errorMsg && isRejectionError(errorMsg)) {
                     Analytics.auth.dropOff('ecosystem-app-connect', {
                         ...(appName && { appName }),
                     });

--- a/packages/vechain-kit/src/hooks/login/useLoginWithOAuth.ts
+++ b/packages/vechain-kit/src/hooks/login/useLoginWithOAuth.ts
@@ -2,6 +2,7 @@ import { useLoginWithOAuth as usePrivyLoginWithOAuth } from '@privy-io/react-aut
 import { Analytics } from '@/utils/mixpanelClientInstance';
 import { VeLoginMethod, VePrivySocialLoginMethod } from '@/types/mixPanel';
 import { usePrivy } from '@privy-io/react-auth';
+import { isRejectionError } from '@/utils/StringUtils';
 
 type OAuthProvider = 'google' | 'twitter' | 'apple' | 'discord';
 
@@ -47,10 +48,7 @@ export const useLoginWithOAuth = () => {
             const errorMsg =
                 error instanceof Error ? error.message : 'Unknown error';
 
-            if (
-                errorMsg.toLowerCase().includes('rejected') ||
-                errorMsg.toLowerCase().includes('closed')
-            ) {
+            if (isRejectionError(errorMsg)) {
                 Analytics.auth.dropOff('oauth', {
                     ...(provider && { provider }),
                 });

--- a/packages/vechain-kit/src/hooks/login/useLoginWithVeChain.ts
+++ b/packages/vechain-kit/src/hooks/login/useLoginWithVeChain.ts
@@ -5,6 +5,7 @@ import { VECHAIN_PRIVY_APP_ID } from '@/utils';
 import { handlePopupError } from '@/utils/handlePopupError';
 import { VeLoginMethod } from '@/types/mixPanel';
 import { Analytics } from '@/utils/mixpanelClientInstance';
+import { isRejectionError } from '@/utils/StringUtils';
 
 export const useLoginWithVeChain = () => {
     const { login: loginWithVeChain } = usePrivyCrossAppSdk();
@@ -33,10 +34,7 @@ export const useLoginWithVeChain = () => {
             const errorMsg =
                 error instanceof Error ? error.message : 'Unknown error';
 
-            if (
-                errorMsg.toLowerCase().includes('rejected') ||
-                errorMsg.toLowerCase().includes('closed')
-            ) {
+            if (isRejectionError(errorMsg)) {
                 Analytics.auth.dropOff('vechain-approval');
             } else {
                 Analytics.auth.failed(VeLoginMethod.VECHAIN, errorMsg);

--- a/packages/vechain-kit/src/hooks/transactions/useSendTransaction.ts
+++ b/packages/vechain-kit/src/hooks/transactions/useSendTransaction.ts
@@ -73,7 +73,7 @@ type UseSendTransactionProps = {
         | (() => EnhancedClause[])
         | (() => Promise<EnhancedClause[]>);
     onTxConfirmed?: () => void | Promise<void>;
-    onTxFailedOrCancelled?: (error?: Error) => void | Promise<void>;
+    onTxFailedOrCancelled?: (error?: Error | string) => void | Promise<void>;
     suggestedMaxGas?: number;
     privyUIOptions?: {
         title?: string;
@@ -280,7 +280,9 @@ export const useSendTransaction = ({
                 setSendTransactionError(
                     error instanceof Error ? error.message : String(error),
                 );
-                onTxFailedOrCancelled?.(error as Error);
+                onTxFailedOrCancelled?.(
+                    error instanceof Error ? error : new Error(String(error)),
+                );
             } finally {
                 setSendTransactionPending(false);
             }

--- a/packages/vechain-kit/src/hooks/transactions/useTransferERC20.ts
+++ b/packages/vechain-kit/src/hooks/transactions/useTransferERC20.ts
@@ -17,7 +17,7 @@ type useTransferERC20Props = {
     tokenName: string;
     onSuccess?: () => void;
     onSuccessMessageTitle?: number;
-    onError?: () => void;
+    onError?: (error?: string) => void;
 };
 
 type useTransferERC20ReturnValue = {
@@ -74,8 +74,8 @@ export const useTransferERC20 = ({
             buttonText: 'Sign to continue',
         },
         onTxConfirmed: handleOnSuccess,
-        onTxFailedOrCancelled: async () => {
-            onError?.();
+        onTxFailedOrCancelled: async (error) => {
+            onError?.(error instanceof Error ? error.message : String(error));
         },
     });
 

--- a/packages/vechain-kit/src/hooks/transactions/useTransferVET.ts
+++ b/packages/vechain-kit/src/hooks/transactions/useTransferVET.ts
@@ -12,7 +12,7 @@ type useTransferVETProps = {
     receiverAddress: string;
     amount: string;
     onSuccess?: () => void;
-    onError?: () => void;
+    onError?: (error?: string) => void;
 };
 
 type useTransferVETReturnValue = {
@@ -67,8 +67,8 @@ export const useTransferVET = ({
             refresh();
             onSuccess?.();
         },
-        onTxFailedOrCancelled: async () => {
-            onError?.();
+        onTxFailedOrCancelled: async (error) => {
+            onError?.(error instanceof Error ? error.message : String(error));
         },
     });
 

--- a/packages/vechain-kit/src/utils/StringUtils.ts
+++ b/packages/vechain-kit/src/utils/StringUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Checks if a string contains common rejection-related terms
+ * @param errorMessage The error message to check
+ * @returns boolean indicating if the message contains rejection terms
+ */
+export const isRejectionError = (errorMessage: string): boolean => {
+    if (!errorMessage) return false;
+    const rejectionTerms = ['rejected', 'cancelled', 'user denied', 'closed'];
+    return rejectionTerms.some((term) =>
+        errorMessage.toLowerCase().includes(term.toLowerCase()),
+    );
+};

--- a/packages/vechain-kit/src/utils/handlePopupError.ts
+++ b/packages/vechain-kit/src/utils/handlePopupError.ts
@@ -1,4 +1,5 @@
 import { isMobile } from 'react-device-detect';
+import { isRejectionError } from './StringUtils';
 
 type PopupErrorOptions = {
     error: unknown;
@@ -16,12 +17,12 @@ export const handlePopupError = ({
     const errorMsg = (error as { message?: string })?.message;
 
     // If it's mobile browser and not a user rejection, it might be due to popup blocking
-    if (isMobile && !errorMsg?.includes('rejected')) {
+    if (isMobile && errorMsg && !isRejectionError(errorMsg)) {
         return new Error(mobileBrowserPopupMessage);
     }
 
     // Handle user rejection or other errors
-    if (errorMsg?.includes('rejected') || errorMsg?.includes('closed')) {
+    if (errorMsg && isRejectionError(errorMsg)) {
         return new Error(rejectedMessage);
     }
 


### PR DESCRIPTION
### Description

- introduce `isRejectionError` util to standardise rejection error checks
- update error handling in various components to utilize the new util

Closes #215 

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [x] vechain-kit
