### PR TITLE
Fix/navigation+refresh-image

### DIFF
--- a/examples/homepage/src/app/components/features/FeaturesToTry/FeatureCard.tsx
+++ b/examples/homepage/src/app/components/features/FeaturesToTry/FeatureCard.tsx
@@ -1,7 +1,15 @@
 'use client';
 
-import { Box, VStack, Text, Icon, useColorMode } from '@chakra-ui/react';
+import {
+    Box,
+    VStack,
+    Text,
+    Icon,
+    useColorMode,
+    HStack,
+} from '@chakra-ui/react';
 import { IconType } from 'react-icons';
+import { FaHandPointLeft } from 'react-icons/fa';
 
 interface FeatureCardProps {
     title: string;
@@ -10,6 +18,7 @@ interface FeatureCardProps {
     highlight?: boolean;
     content: () => void;
     disabled?: boolean;
+    showHint?: boolean;
 }
 
 export function FeatureCard({
@@ -19,6 +28,7 @@ export function FeatureCard({
     highlight,
     content,
     disabled = false,
+    showHint = false,
 }: FeatureCardProps) {
     const { colorMode } = useColorMode();
 
@@ -46,11 +56,55 @@ export function FeatureCard({
             height="full"
         >
             <VStack spacing={3} align="start">
-                <Icon
-                    as={icon}
-                    boxSize={6}
-                    color={colorMode === 'light' ? 'blue.500' : 'blue.300'}
-                />
+                <HStack>
+                    <Icon
+                        as={icon}
+                        boxSize={6}
+                        color={colorMode === 'light' ? 'blue.500' : 'blue.300'}
+                    />
+                    {showHint && (
+                        <HStack
+                            spacing={3}
+                            animation="bounce-left 1s infinite"
+                            justifyContent="center"
+                            alignItems="center"
+                            transform="rotate(-10deg)"
+                            sx={{
+                                '@keyframes bounce-left': {
+                                    '0%, 100%': {
+                                        transform: 'rotate(0deg) translateX(0)',
+                                    },
+                                    '50%': {
+                                        transform:
+                                            'rotate(0deg) translateX(-5px)',
+                                    },
+                                },
+                            }}
+                        >
+                            <FaHandPointLeft
+                                size={24}
+                                rotate={10}
+                                color={
+                                    colorMode === 'light'
+                                        ? '#4A5568'
+                                        : '#A0AEC0'
+                                }
+                                style={{ marginLeft: '8px' }}
+                            />
+
+                            <Text
+                                fontSize="sm"
+                                color={
+                                    colorMode === 'light'
+                                        ? 'gray.600'
+                                        : 'gray.400'
+                                }
+                            >
+                                Click me!
+                            </Text>
+                        </HStack>
+                    )}
+                </HStack>
                 <Text fontWeight="bold">{title}</Text>
                 <Text
                     fontSize="sm"

--- a/examples/homepage/src/app/components/features/FeaturesToTry/FeaturesToTry.tsx
+++ b/examples/homepage/src/app/components/features/FeaturesToTry/FeaturesToTry.tsx
@@ -122,8 +122,12 @@ export function FeaturesToTry() {
             </Text>
 
             <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
-                {features.map((feature) => (
-                    <FeatureCard key={feature.title} {...feature} />
+                {features.map((feature, index) => (
+                    <FeatureCard
+                        key={feature.title}
+                        {...feature}
+                        showHint={index === 0}
+                    />
                 ))}
                 <LanguageCard />
                 <ThemeCard />

--- a/examples/homepage/src/app/components/features/Introduction/Introduction.tsx
+++ b/examples/homepage/src/app/components/features/Introduction/Introduction.tsx
@@ -140,183 +140,208 @@ export function Introduction() {
                 </Box>
             </VStack>
 
-            <VStack mt={14} spacing={6} align="stretch">
-                <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
-                    <Box p={4} borderRadius="md" borderWidth="1px">
-                        <VStack align="start" spacing={3}>
-                            <Icon as={CiLogin} boxSize={6} color="blue.400" />
-                            <Text fontWeight="bold">
-                                Wallet Connection Integration
-                            </Text>
-                            <Text>
-                                Easily connect your users to your dApp with out
-                                of the box wallet connection options. Choose
-                                between:
-                            </Text>
-                            <HStack spacing={3} wrap="wrap">
-                                <Icon as={FcGoogle} boxSize={6} />
-                                <Icon as={FaSquareXTwitter} boxSize={6} />
-                                <Icon as={MdEmail} boxSize={6} />
-                                <Icon as={FaDiscord} boxSize={6} />
-                                <Icon as={SiFarcaster} boxSize={6} />
-                                <Icon as={FaApple} boxSize={6} />
-                                <Image
-                                    src={`${basePath}/images/veworld-logo.png`}
-                                    alt="VeWorld"
-                                    height={6}
-                                    width="auto"
-                                    borderRadius="md"
-                                />
-                                <Image
-                                    src={`${basePath}/images/wallet-connect-logo.png`}
-                                    alt="WalletConnect"
-                                    height={6}
-                                    width="auto"
-                                    borderRadius="md"
-                                />
-                                <Image
-                                    src={`${basePath}/images/rabby-logo.png`}
-                                    alt="Rabby Wallet"
-                                    height={6}
-                                    width="auto"
-                                    borderRadius="md"
-                                />
-                                <Image
-                                    src={`${basePath}/images/metamask-logo.png`}
-                                    alt="MetaMask"
-                                    height={6}
-                                    width="auto"
-                                    borderRadius="md"
-                                />
-                                <Image
-                                    src={`${basePath}/images/coinbase-wallet-logo.webp`}
-                                    alt="Coinbase Wallet"
-                                    height={6}
-                                    width="auto"
-                                    borderRadius="md"
-                                />
-                                <Image
-                                    src={`${basePath}/images/rainbow-logo.webp`}
-                                    alt="Rainbow"
-                                    height={6}
-                                    width="auto"
-                                    borderRadius="md"
-                                />
-                                <Text fontSize="sm" color="gray.400">
-                                    and more...
-                                </Text>
-                            </HStack>
-                        </VStack>
-                    </Box>
+            {!connection.isConnected && (
+                <>
+                    <VStack mt={14} spacing={6} align="stretch">
+                        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
+                            <Box p={4} borderRadius="md" borderWidth="1px">
+                                <VStack align="start" spacing={3}>
+                                    <Icon
+                                        as={CiLogin}
+                                        boxSize={6}
+                                        color="blue.400"
+                                    />
+                                    <Text fontWeight="bold">
+                                        Wallet Connection Integration
+                                    </Text>
+                                    <Text>
+                                        Easily connect your users to your dApp
+                                        with out of the box wallet connection
+                                        options. Choose between:
+                                    </Text>
+                                    <HStack spacing={3} wrap="wrap">
+                                        <Icon as={FcGoogle} boxSize={6} />
+                                        <Icon
+                                            as={FaSquareXTwitter}
+                                            boxSize={6}
+                                        />
+                                        <Icon as={MdEmail} boxSize={6} />
+                                        <Icon as={FaDiscord} boxSize={6} />
+                                        <Icon as={SiFarcaster} boxSize={6} />
+                                        <Icon as={FaApple} boxSize={6} />
+                                        <Image
+                                            src={`${basePath}/images/veworld-logo.png`}
+                                            alt="VeWorld"
+                                            height={6}
+                                            width="auto"
+                                            borderRadius="md"
+                                        />
+                                        <Image
+                                            src={`${basePath}/images/wallet-connect-logo.png`}
+                                            alt="WalletConnect"
+                                            height={6}
+                                            width="auto"
+                                            borderRadius="md"
+                                        />
+                                        <Image
+                                            src={`${basePath}/images/rabby-logo.png`}
+                                            alt="Rabby Wallet"
+                                            height={6}
+                                            width="auto"
+                                            borderRadius="md"
+                                        />
+                                        <Image
+                                            src={`${basePath}/images/metamask-logo.png`}
+                                            alt="MetaMask"
+                                            height={6}
+                                            width="auto"
+                                            borderRadius="md"
+                                        />
+                                        <Image
+                                            src={`${basePath}/images/coinbase-wallet-logo.webp`}
+                                            alt="Coinbase Wallet"
+                                            height={6}
+                                            width="auto"
+                                            borderRadius="md"
+                                        />
+                                        <Image
+                                            src={`${basePath}/images/rainbow-logo.webp`}
+                                            alt="Rainbow"
+                                            height={6}
+                                            width="auto"
+                                            borderRadius="md"
+                                        />
+                                        <Text fontSize="sm" color="gray.400">
+                                            and more...
+                                        </Text>
+                                    </HStack>
+                                </VStack>
+                            </Box>
 
-                    <Box p={4} borderRadius="md" borderWidth="1px">
-                        <VStack align="start" spacing={3}>
-                            <Icon
-                                as={IoWalletOutline}
-                                boxSize={6}
-                                color="blue.400"
-                            />
-                            <Text fontWeight="bold">
-                                Assets, Profile, and Wallet Management
-                            </Text>
-                            <Text>
-                                Use VeChain Kit to allow your users to have
-                                asset management, profile management, social
-                                login, wallet backup, mfa, and more. All out of
-                                the box, so you can focus on building your dApp.
-                            </Text>
-                        </VStack>
-                    </Box>
+                            <Box p={4} borderRadius="md" borderWidth="1px">
+                                <VStack align="start" spacing={3}>
+                                    <Icon
+                                        as={IoWalletOutline}
+                                        boxSize={6}
+                                        color="blue.400"
+                                    />
+                                    <Text fontWeight="bold">
+                                        Assets, Profile, and Wallet Management
+                                    </Text>
+                                    <Text>
+                                        Use VeChain Kit to allow your users to
+                                        have asset management, profile
+                                        management, social login, wallet backup,
+                                        mfa, and more. All out of the box, so
+                                        you can focus on building your dApp.
+                                    </Text>
+                                </VStack>
+                            </Box>
 
-                    <Box p={4} borderRadius="md" borderWidth="1px">
-                        <VStack align="start" spacing={3}>
-                            <Icon as={MdCode} boxSize={6} color="green.400" />
-                            <Text fontWeight="bold">Boosted development</Text>
-                            <Text>
-                                Use our hooks and components to speed up your
-                                development. No need to worry about the
-                                underlying VeChain infrastructure, we handle it
-                                for you.
-                            </Text>
-                        </VStack>
-                    </Box>
+                            <Box p={4} borderRadius="md" borderWidth="1px">
+                                <VStack align="start" spacing={3}>
+                                    <Icon
+                                        as={MdCode}
+                                        boxSize={6}
+                                        color="green.400"
+                                    />
+                                    <Text fontWeight="bold">
+                                        Boosted development
+                                    </Text>
+                                    <Text>
+                                        Use our hooks and components to speed up
+                                        your development. No need to worry about
+                                        the underlying VeChain infrastructure,
+                                        we handle it for you.
+                                    </Text>
+                                </VStack>
+                            </Box>
 
-                    <Box p={4} borderRadius="md" borderWidth="1px">
-                        <VStack align="start" spacing={3}>
-                            <Icon as={MdBrush} boxSize={6} color="purple.400" />
-                            <Text fontWeight="bold">Style customization</Text>
-                            <Text>
-                                The kit is designed to be customizable to your
-                                needs. Decide what features you want to use and
-                                which ones you don't. Add call to action buttons
-                                to your app to guide your users to the features
-                                they need.
-                            </Text>
-                        </VStack>
-                    </Box>
-                </SimpleGrid>
-            </VStack>
+                            <Box p={4} borderRadius="md" borderWidth="1px">
+                                <VStack align="start" spacing={3}>
+                                    <Icon
+                                        as={MdBrush}
+                                        boxSize={6}
+                                        color="purple.400"
+                                    />
+                                    <Text fontWeight="bold">
+                                        Style customization
+                                    </Text>
+                                    <Text>
+                                        The kit is designed to be customizable
+                                        to your needs. Decide what features you
+                                        want to use and which ones you don't.
+                                        Add call to action buttons to your app
+                                        to guide your users to the features they
+                                        need.
+                                    </Text>
+                                </VStack>
+                            </Box>
+                        </SimpleGrid>
+                    </VStack>
 
-            <VStack mt={8} spacing={4} align="stretch">
-                <Heading size="sm" textAlign="center">
-                    Explore some of the apps built with VeChain Kit
-                </Heading>
-                <Text textAlign="center" fontSize="xs">
-                    (This website is built with VeChain Kit as well!)
-                </Text>
-                <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
-                    {[
-                        {
-                            name: 'EatGreen',
-                            href: 'https://eatgreen.aworld.org/',
-                            logo: 'https://i.ibb.co/zVx7ncgq/download-2.png',
-                        },
-                        {
-                            name: 'ScoopUp',
-                            href: 'https://scoopup.vet/',
-                            logo: 'https://scoopup.vet/images/logo.webp',
-                        },
-                        {
-                            name: 'VeLottery',
-                            href: 'https://velottery.vet/',
-                            logo: 'https://velottery.vet/assets/logo.png',
-                        },
-                    ].map((app) => (
-                        <Box
-                            key={app.name}
-                            p={3}
-                            borderRadius="md"
-                            borderWidth="1px"
-                            role="group"
-                            as={Link}
-                            href={app.href}
-                            isExternal
-                            onClick={() =>
-                                trackExternalLink(
-                                    `example-app-${app.name.toLowerCase()}`,
-                                )
-                            }
-                        >
-                            <HStack
-                                align="start"
-                                spacing={2}
-                                alignItems={'center'}
-                            >
-                                <Image
-                                    src={app.logo}
-                                    alt={app.name}
-                                    width={'auto'}
-                                    height={10}
+                    <VStack mt={8} spacing={4} align="stretch">
+                        <Heading size="sm" textAlign="center">
+                            Explore some of the apps built with VeChain Kit
+                        </Heading>
+                        <Text textAlign="center" fontSize="xs">
+                            (This website is built with VeChain Kit as well!)
+                        </Text>
+                        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+                            {[
+                                {
+                                    name: 'EatGreen',
+                                    href: 'https://eatgreen.aworld.org/',
+                                    logo: 'https://i.ibb.co/zVx7ncgq/download-2.png',
+                                },
+                                {
+                                    name: 'ScoopUp',
+                                    href: 'https://scoopup.vet/',
+                                    logo: 'https://scoopup.vet/images/logo.webp',
+                                },
+                                {
+                                    name: 'VeLottery',
+                                    href: 'https://velottery.vet/',
+                                    logo: 'https://velottery.vet/assets/logo.png',
+                                },
+                            ].map((app) => (
+                                <Box
+                                    key={app.name}
+                                    p={3}
                                     borderRadius="md"
-                                />
-                                <Text fontWeight="bold" fontSize="sm">
-                                    {app.name}
-                                </Text>
-                            </HStack>
-                        </Box>
-                    ))}
-                </SimpleGrid>
-            </VStack>
+                                    borderWidth="1px"
+                                    role="group"
+                                    as={Link}
+                                    href={app.href}
+                                    isExternal
+                                    onClick={() =>
+                                        trackExternalLink(
+                                            `example-app-${app.name.toLowerCase()}`,
+                                        )
+                                    }
+                                >
+                                    <HStack
+                                        align="start"
+                                        spacing={2}
+                                        alignItems={'center'}
+                                    >
+                                        <Image
+                                            src={app.logo}
+                                            alt={app.name}
+                                            width={'auto'}
+                                            height={10}
+                                            borderRadius="md"
+                                        />
+                                        <Text fontWeight="bold" fontSize="sm">
+                                            {app.name}
+                                        </Text>
+                                    </HStack>
+                                </Box>
+                            ))}
+                        </SimpleGrid>
+                    </VStack>
+                </>
+            )}
         </Box>
     );
 }

--- a/examples/homepage/src/app/pages/Home.tsx
+++ b/examples/homepage/src/app/pages/Home.tsx
@@ -174,7 +174,6 @@ export default function Home(): ReactElement {
 
                 <UIControls />
 
-                {/* <LanguageSelector /> */}
                 <TransactionExamples />
                 <SigningExample />
                 <DataReadingExample />

--- a/examples/homepage/src/app/pages/Home.tsx
+++ b/examples/homepage/src/app/pages/Home.tsx
@@ -167,7 +167,6 @@ export default function Home(): ReactElement {
                 )}
 
                 <Introduction />
-                <LoginUIControl />
 
                 <div ref={featuresRef}>
                     <FeaturesToTry />

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationContent.tsx
@@ -243,7 +243,7 @@ export const CustomizationContent = ({
                 reason: 'back_button',
             });
         }
-        setCurrentContent('profile');
+        setCurrentContent(initialContentSource);
     };
 
     return (

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/ProfileContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/ProfileContent.tsx
@@ -52,6 +52,7 @@ export const ProfileContent = ({
                                 type: 'account-customization',
                                 props: {
                                     setCurrentContent,
+                                    initialContentSource: 'profile',
                                 },
                             });
                         }}


### PR DESCRIPTION
### Description

- Fixed an issue when navigating to customize profile from settings, when clicking the back button it was bringing the user to the profile instead of settings.

- When updating the image there is still some issue with the refresh, but here I try an alternative approach, where, since we already have the image locally, we just set the content of the query instead of refetching it. Seems to work fine.

### Updated packages (if any):

-  [ ] next-template
-  [x] homepage
-  [x] vechain-kit
