### PR TITLE
fix: transaction status when sending txs

### DIFF
--- a/packages/vechain-kit/src/hooks/transactions/useSendTransaction.ts
+++ b/packages/vechain-kit/src/hooks/transactions/useSendTransaction.ts
@@ -349,6 +349,10 @@ export const useSendTransaction = ({
                 }
                 return 'success';
             }
+
+            // By default we return waitingConfirmation because we have a txid,
+            // so it means the tx is broadcasted (even if the receipt is not yet available)
+            return 'waitingConfirmation';
         }
 
         return 'ready';


### PR DESCRIPTION
### Description

By default we return `waitingConfirmation` because we have a txid, so it means the tx is broadcasted (even if the receipt is not yet available). Returnin "ready" was causing UI flickering (because of modals disappearing and appearing again)

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [x] vechain-kit
