### PR TITLE
fix: create wallet after login

### DIFF
--- a/packages/vechain-kit/src/components/ConnectModal/Components/LoginWithGoogleButton.tsx
+++ b/packages/vechain-kit/src/components/ConnectModal/Components/LoginWithGoogleButton.tsx
@@ -19,10 +19,10 @@ export const LoginWithGoogleButton = ({ isDark, gridColumn }: Props) => {
         <GridItem colSpan={gridColumn ?? 4} w={'full'}>
             <ConnectionButton
                 isDark={isDark}
-                onClick={() => {
+                onClick={async () => {
                     Analytics.auth.flowStarted(VeLoginMethod.GOOGLE);
                     Analytics.auth.methodSelected(VeLoginMethod.GOOGLE);
-                    initOAuth({
+                    await initOAuth({
                         provider: 'google',
                     });
                 }}

--- a/packages/vechain-kit/src/components/EmailCodeVerificationModal/EmailCodeVerificationModal.tsx
+++ b/packages/vechain-kit/src/components/EmailCodeVerificationModal/EmailCodeVerificationModal.tsx
@@ -15,7 +15,7 @@ import {
 import { MdEmail } from 'react-icons/md';
 import { BaseModal, StickyHeaderContainer } from '../common';
 import { useEffect, useState } from 'react';
-import { useLoginWithEmail } from '@privy-io/react-auth';
+import { useCreateWallet, useLoginWithEmail } from '@privy-io/react-auth';
 import { useTranslation } from 'react-i18next';
 import { useVeChainKitConfig } from '@/providers';
 
@@ -38,7 +38,17 @@ export const EmailCodeVerificationModal = ({
     const { darkMode: isDark } = useVeChainKitConfig();
     const [code, setCode] = useState('');
     const [error, setError] = useState<string | null>(null);
-    const { loginWithCode } = useLoginWithEmail({});
+
+    const { createWallet } = useCreateWallet();
+    const { loginWithCode } = useLoginWithEmail({
+        onComplete: async ({ isNewUser }) => {
+            // When using initOAuth Privy does not create an embedded wallet automatically.
+            // So we need to create a wallet manually.
+            if (isNewUser) {
+                await createWallet();
+            }
+        },
+    });
 
     useEffect(() => {
         if (code.length === 6) {


### PR DESCRIPTION
### Description

Manually ask Privy to create wallet when using loginWithOAuth or loginWithEmail (currently used only for email input and lgoin with google button, but it's exported and other apps can use it as well if they have their own Privy account)

Closes #263 

### Updated packages (if any):

-  [ ] next-template
-  [ ] homepage
-  [x] vechain-kit
