### PR TITLE
integrate OAuth authentication tracking under single category

### DIFF
--- a/packages/vechain-kit/src/hooks/login/useLoginWithOAuth.ts
+++ b/packages/vechain-kit/src/hooks/login/useLoginWithOAuth.ts
@@ -10,13 +10,6 @@ interface OAuthOptions {
     provider: OAuthProvider;
 }
 
-const providerToLoginMethod: Record<OAuthProvider, VeLoginMethod> = {
-    google: VeLoginMethod.GOOGLE,
-    twitter: VeLoginMethod.EMAIL,
-    apple: VeLoginMethod.EMAIL,
-    discord: VeLoginMethod.EMAIL,
-};
-
 const providerToSocialMethod: Record<OAuthProvider, VePrivySocialLoginMethod> =
     {
         google: VePrivySocialLoginMethod.EMAIL,
@@ -30,7 +23,7 @@ export const useLoginWithOAuth = () => {
     const { user } = usePrivy();
 
     const initOAuth = async ({ provider }: OAuthOptions) => {
-        const loginMethod = providerToLoginMethod[provider];
+        const loginMethod = VeLoginMethod.OAUTH;
         const socialMethod = providerToSocialMethod[provider];
 
         try {

--- a/packages/vechain-kit/src/types/mixPanel.ts
+++ b/packages/vechain-kit/src/types/mixPanel.ts
@@ -5,6 +5,7 @@ export enum VeLoginMethod {
     DAPPKIT = 'dappkit',
     ECOSYSTEM = 'ecosystem',
     PASSKEY = 'passkey',
+    OAUTH = 'oauth',
     MORE = 'more',
 }
 


### PR DESCRIPTION
### Description
This PR updates our OAuth login tracking to use a consistent "oauth" value rather than mapping different providers to various login methods

Closes #265 

### Updated packages (if any):
-  [x] vechain-kit
