### PR TITLE
Fix(LegalDocuments): Memoize pending docs with storage dependency

### DIFF
--- a/examples/homepage/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/homepage/src/app/providers/VechainKitProviderWrapper.tsx
@@ -94,6 +94,9 @@ export function VechainKitProviderWrapper({ children }: Props) {
                 // nodeUrl: 'http://localhost:8669',
             }}
             allowCustomTokens={true}
+            legalDocuments={{
+                allowAnalytics: true,
+            }}
         >
             {children}
         </VeChainKitProvider>

--- a/packages/vechain-kit/src/components/LegalDocumentsModal/LegalDocumentsContent.tsx
+++ b/packages/vechain-kit/src/components/LegalDocumentsModal/LegalDocumentsContent.tsx
@@ -10,7 +10,7 @@ import {
     Text,
     VStack,
 } from '@chakra-ui/react';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Fragment } from 'react';
 import { useForm } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
@@ -80,21 +80,21 @@ export const LegalDocumentsContent = ({
     // Calculate if all optional documents are selected
     const allSelected = documentsNotAgreed?.length === selectedDocuments.length;
 
-    const onSubmit = (data: Record<string, boolean>) => {
-        const agreedDocumentIds = new Set(
-            Object.entries(data)
-                .filter(([_, checked]) => checked)
-                .map(([docId]) => docId),
-        );
+    const onSubmit = useCallback(
+        (data: Record<string, boolean>) => {
+            const agreedDocumentIds = new Set(
+                Object.entries(data)
+                    .filter(([_, checked]) => checked)
+                    .map(([docId]) => docId),
+            );
 
-        const agreedDocuments = documentsNotAgreed.filter((document) =>
-            agreedDocumentIds.has(document.id),
-        );
-
-        if (agreedDocuments.length > 0 || onlyOptionalDocuments) {
+            const agreedDocuments = documentsNotAgreed.filter((document) =>
+                agreedDocumentIds.has(document.id),
+            );
             return onAgree(agreedDocuments);
-        }
-    };
+        },
+        [documentsNotAgreed, onAgree],
+    );
 
     const borderColor = isDark ? '#3a3a3a' : '#eaeaea';
     const sectionBgColor = isDark ? '#2a2a2a' : '#f5f5f5';

--- a/packages/vechain-kit/src/utils/legalDocumentsUtils.ts
+++ b/packages/vechain-kit/src/utils/legalDocumentsUtils.ts
@@ -1,5 +1,4 @@
 import { EnrichedLegalDocument, LegalDocumentAgreement } from '@/types';
-import { compareAddresses } from '@/utils';
 
 export const LEGAL_DOCS_LOCAL_STORAGE_KEY = 'vechain-kit-legal-documents';
 export const LEGAL_DOCS_OPTIONAL_REJECT_LOCAL_STORAGE_KEY =
@@ -76,42 +75,6 @@ export const getStoredRejectedDocuments = (): LegalDocumentAgreement[] => {
         );
         return [];
     }
-};
-
-/**
- * Get documents that a user has not agreed to
- */
-export const getDocumentsNotAgreed = (
-    walletAddress: string | undefined,
-    documents: EnrichedLegalDocument[],
-): EnrichedLegalDocument[] => {
-    if (!walletAddress) return [];
-
-    const agreements = getStoredAgreements();
-    const rejections = getStoredRejectedDocuments();
-
-    return documents.filter((document) => {
-        // Filter out documents that have been agreed to
-        const isAgreed = agreements.some(
-            (agreement) =>
-                compareAddresses(agreement.walletAddress, walletAddress) &&
-                agreement.id === document.id,
-        );
-
-        if (isAgreed) return false;
-
-        // Filter out optional documents that have been explicitly rejected
-        const isRejected = rejections.some(
-            (rejection) =>
-                compareAddresses(rejection.walletAddress, walletAddress) &&
-                rejection.id === document.id,
-        );
-
-        if (isRejected) return false;
-
-        // Keep the document if it's neither agreed nor rejected
-        return true;
-    });
 };
 
 /**


### PR DESCRIPTION
### Description


A bug was found where, if analytics is enabled and the user accepts both the required terms and the optional ones (enabled via `allowAnalytics: true`), the modal would prompt for acceptance twice.

This happened because `handleAgree` correctly updated the storage, but `documentsNotAgreed` was a memoized constant based on a getter that wasn't updating in response to storage changes. In this case, it caused the flow to break and show the modal again unnecessarily.

ℹ️ In addition, this PR enables analytics from `vechain-kit` homepage by default

### Bug

https://github.com/user-attachments/assets/c6339f4d-8383-4b4d-90b2-3fe169245b55


### PR Fix

https://github.com/user-attachments/assets/0953b585-32dc-4b62-ae95-c63b526d1bd4



### Updated packages (if any):

-  [ ] next-template
-  [x] homepage
-  [x] vechain-kit
