### PR TITLE
chore: mark contracts package as private

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -4,6 +4,7 @@
     "main": "index.ts",
     "types": "index.ts",
     "license": "MIT",
+    "private": true,
     "scripts": {
         "compile": "yarn hardhat compile",
         "deploy:hardhat": "npx hardhat run scripts/deploy --network hardhat",


### PR DESCRIPTION
### Description

Add private flag to contracts package to prevent npm publishing

Closes #347 

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [ ] vechain-kit
-   [x] contracts
