### PR TITLE
feat: add type safe useEvents and useMultipleClausesCall

### DIFF
--- a/packages/vechain-kit/src/hooks/utils/index.ts
+++ b/packages/vechain-kit/src/hooks/utils/index.ts
@@ -5,3 +5,4 @@ export * from './useFeatureAnnouncement';
 export * from './useGetNodeUrl';
 export * from './useIsPwa';
 export * from './useScrollToTop';
+export * from './useEvents';

--- a/packages/vechain-kit/src/hooks/utils/useCallClause.ts
+++ b/packages/vechain-kit/src/hooks/utils/useCallClause.ts
@@ -1,11 +1,17 @@
-import { executeCallClause, ViewFunctionResult } from '@/utils';
+import {
+    executeCallClause,
+    executeMultipleClausesCall,
+    MultipleClausesCallParameters,
+    ViewFunctionResult,
+} from '@/utils';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { useThor } from '@vechain/dapp-kit-react';
+import { ThorClient } from '@vechain/sdk-network';
 import {
     ExtractAbiFunctionNames,
     AbiParametersToPrimitiveTypes,
 } from 'abitype';
-import { Abi } from 'viem';
+import { Abi, ContractFunctionParameters } from 'viem';
 
 export * from '@/utils/thorUtils';
 
@@ -103,3 +109,23 @@ export const useCallClause = <
         ...queryOptions,
     });
 };
+
+export const useMultipleClausesCall = <
+    contracts extends readonly ContractFunctionParameters[],
+    allowFailure extends boolean = false,
+>({
+    thor,
+    calls,
+    queryKey,
+    enabled = true,
+}: {
+    thor: ThorClient;
+    calls: MultipleClausesCallParameters<contracts, allowFailure>;
+    queryKey: string[];
+    enabled?: boolean;
+}) =>
+    useQuery({
+        queryKey,
+        queryFn: () => executeMultipleClausesCall({ thor, calls }),
+        enabled,
+    });

--- a/packages/vechain-kit/src/hooks/utils/useEvents.ts
+++ b/packages/vechain-kit/src/hooks/utils/useEvents.ts
@@ -1,0 +1,140 @@
+import { useQuery } from '@tanstack/react-query';
+import { EventLogs, FilterCriteria } from '@vechain/sdk-network';
+import { useCallback, useMemo } from 'react';
+import {
+    Abi,
+    ContractEventName,
+    decodeEventLog as viemDecodeEventLog,
+    Hex as ViemHex,
+} from 'viem';
+import { useThor } from '@vechain/dapp-kit-react';
+import { getAllEventLogs } from '../thor';
+
+type Topics = [] | [signature: ViemHex, ...args: ViemHex[]];
+
+export const decodeEventLog = <TAbi extends Abi>(
+    event: EventLogs,
+    abi: TAbi,
+): {
+    meta: EventLogs['meta'];
+    decodedData: ReturnType<typeof viemDecodeEventLog<TAbi>>;
+} => {
+    const decodedData = viemDecodeEventLog({
+        abi,
+        data: event.data.toString() as ViemHex,
+        topics: event.topics.map((topic) => topic.toString()) as Topics,
+    });
+
+    return {
+        meta: event.meta,
+        decodedData,
+    };
+};
+
+export type UseEventsParams<
+    T extends Abi,
+    K extends ContractEventName<T>,
+    R,
+> = {
+    abi: T;
+    contractAddress: string;
+    eventName: K;
+    filterParams?: Record<string, unknown> | unknown[] | undefined;
+    mapResponse: ({
+        meta,
+        decodedData,
+    }: {
+        meta: EventLogs['meta'];
+        decodedData: ReturnType<typeof viemDecodeEventLog<T, K>>;
+    }) => R;
+    nodeUrl: string;
+};
+
+export type GetEventsKeyParams = {
+    eventName: string;
+    filterParams?: object;
+};
+
+export const getEventsKey = ({
+    eventName,
+    filterParams,
+}: GetEventsKeyParams) => {
+    return [eventName, filterParams ? JSON.stringify(filterParams) : 'all'];
+};
+
+/**
+ * Custom hook for fetching contract events.
+ */
+export const useEvents = <T extends Abi, K extends ContractEventName<T>, R>({
+    abi,
+    contractAddress,
+    eventName,
+    filterParams,
+    mapResponse,
+    nodeUrl,
+}: UseEventsParams<T, K, R>) => {
+    const thor = useThor();
+
+    const queryFn = useCallback(async () => {
+        if (!thor) return [];
+
+        const eventAbi = thor.contracts
+            .load(contractAddress, abi)
+            .getEventAbi(eventName);
+        const topics = eventAbi.encodeFilterTopicsNoNull(filterParams ?? {});
+
+        // Construct filter criteria
+        const filterCriteria: FilterCriteria[] = [
+            {
+                criteria: {
+                    address: contractAddress,
+                    topic0: topics[0] ?? undefined,
+                    topic1: topics[1] ?? undefined,
+                    topic2: topics[2] ?? undefined,
+                    topic3: topics[3] ?? undefined,
+                    topic4: topics[4] ?? undefined,
+                },
+                eventAbi,
+            },
+        ];
+
+        const events = (
+            await getAllEventLogs({ thor, nodeUrl, filterCriteria })
+        ).map((event) => decodeEventLog(event, abi));
+
+        if (
+            events.some(
+                ({ decodedData }) => decodedData.eventName !== eventName,
+            )
+        )
+            throw new Error(`Unknown event`);
+
+        return events.map((event) =>
+            mapResponse({
+                meta: event.meta,
+                decodedData: event.decodedData as ReturnType<
+                    typeof viemDecodeEventLog<T, K>
+                >,
+            }),
+        );
+    }, [
+        thor,
+        contractAddress,
+        abi,
+        eventName,
+        filterParams,
+        mapResponse,
+        nodeUrl,
+    ]);
+
+    const queryKey = useMemo(
+        () => getEventsKey({ eventName, filterParams }),
+        [eventName, filterParams],
+    );
+
+    return useQuery({
+        queryFn,
+        queryKey,
+        enabled: !!thor,
+    });
+};


### PR DESCRIPTION
### Description

useEvents is used in b3tr and it is a utility hook to get events. 
What i thought we can have it in vechain-kit to help users to use type safe event getter. 

useMultipleClausesCall is also added for calling multiple calls in batch with type safety. It is becoming more needed in b3tr as well, so that's why I added this into kit.

>[!Note]
>Not something urgent, we can include it in next release.

Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [x] vechain-kit
-   [ ] contracts
