### PR TITLE
Fix(LegalDocs): Adding Fallback for Unavailable Context - v1

### DIFF
--- a/packages/vechain-kit/src/providers/LegalDocumentsProvider.tsx
+++ b/packages/vechain-kit/src/providers/LegalDocumentsProvider.tsx
@@ -50,9 +50,14 @@ const LegalDocumentsContext = createContext<
 export const useLegalDocuments = () => {
     const context = useContext(LegalDocumentsContext);
     if (!context) {
-        throw new Error(
-            'useLegalDocuments must be used within LegalDocumentsProvider',
-        );
+        // This fallbackis used to avoid errors when the context is not available
+        return {
+            hasAgreedToRequiredDocuments: true,
+            agreements: [],
+            walletAddress: undefined,
+            documents: [],
+            documentsNotAgreed: [],
+        };
     }
     return context;
 };


### PR DESCRIPTION
### Description

This PR adds a fallback and remove the error throw when no context is available. This caused some apps such as https://app.stargate.vechain.org/ and https://www.betterswap.io/ to crash when acessing _Settings > General > Terms and Policies_.

The reason is that the `TermsAndPrivacyAccordion` which is displayed on clicking that button tries to use the `useLegalDocuments` which at the time has no context available since not initialization was done in their `VechainKitProvider`.

Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [x] vechain-kit
-   [ ] contracts
