### PR TITLE
Fix(LegalDocs): Adding Fallback for Unavailable Context - v2 

### DIFF
--- a/packages/vechain-kit/src/providers/LegalDocumentsProvider.tsx
+++ b/packages/vechain-kit/src/providers/LegalDocumentsProvider.tsx
@@ -49,9 +49,14 @@ const LegalDocumentsContext = createContext<
 export const useLegalDocuments = () => {
     const context = useContext(LegalDocumentsContext);
     if (!context) {
-        throw new Error(
-            'useLegalDocuments must be used within LegalDocumentsProvider',
-        );
+        // This fallback is used to avoid errors when the context is not available
+        return {
+            hasAgreedToRequiredDocuments: true,
+            agreements: [],
+            walletAddress: undefined,
+            documents: [],
+            documentsNotAgreed: [],
+        };
     }
     return context;
 };


### PR DESCRIPTION
### Description

This PR adds a fallback and removes the error throw when no context is available. Without this, some apps like https://app.stargate.vechain.org/ and https://www.betterswap.io/ would crash when accessing _Settings > General > Terms and Policies_.

The issue was that `TermsAndPrivacyAccordion` tries to use `useLegalDocuments`, but at that point there’s no context available because their `VechainKitProvider` didn’t initialize it.


https://github.com/user-attachments/assets/a483c50c-c1cf-4b6c-8c0c-f6e18c09f38d


### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [x] vechain-kit
-   [ ] contracts
