### PR TITLE
Fix: `UseSendTransaction` suggested max gas

### DIFF
--- a/packages/vechain-kit/src/hooks/thor/transactions/useSendTransaction.ts
+++ b/packages/vechain-kit/src/hooks/thor/transactions/useSendTransaction.ts
@@ -146,9 +146,8 @@ export const useSendTransaction = ({
 
             const txBody = await thor.transactions.buildTransactionBody(
                 _clauses,
-                estimatedGas,
+                suggestedMaxGas ?? estimatedGas, //Provide either the suggested max gas (gas Limit) or the estimated gas
                 {
-                    gasLimit: suggestedMaxGas?.toString(),
                     // TODO: kit-migration check how to pass the delegator url
                     isDelegated: feeDelegation?.delegateAllTransactions,
                 },


### PR DESCRIPTION
### Description

This PR fixes the way `gasLimit` (or `suggestedMaxGas`) is being set for transactions. Previously, the parameter was being passed incorrectly , the SDK currently does not respect `gasLimit` when passed in the options object.

Instead, the correct approach is to pass it as the second argument to `thor.transactions.buildTransactionBody()`. This sets the maximum allowed gas for the transaction execution, ensuring it's properly enforced.

Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [x] vechain-kit
-   [ ] contracts
