### PR TITLE
fix: use single theme provider wrapper around kit

### DIFF
--- a/packages/vechain-kit/src/components/TransactionToast/TransactionToast.tsx
+++ b/packages/vechain-kit/src/components/TransactionToast/TransactionToast.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { TransactionStatus, TransactionStatusErrorType } from '@/types';
-import { useVeChainKitConfig, VechainKitThemeProvider } from '@/providers';
+import { useVeChainKitConfig } from '@/providers';
 import { TransactionToastContent } from './TransactionToastContent';
 import { TransactionReceipt } from '@vechain/sdk-network';
 
@@ -28,28 +28,26 @@ export const TransactionToast = ({
     if (!isOpen) return null;
 
     return (
-        <VechainKitThemeProvider darkMode={isDark}>
-            <Box
-                position="fixed"
-                bottom="5"
-                left="5"
-                zIndex="11111"
-                bg={isDark ? '#1f1f1e' : 'white'}
-                borderRadius={'md'}
-                p={5}
-                boxShadow="lg"
-                maxW="sm"
-                minW="300px"
-            >
-                <TransactionToastContent
-                    status={status}
-                    txReceipt={txReceipt}
-                    txError={txError}
-                    onTryAgain={onTryAgain}
-                    description={description}
-                    onClose={onClose}
-                />
-            </Box>
-        </VechainKitThemeProvider>
+        <Box
+            position="fixed"
+            bottom="5"
+            left="5"
+            zIndex="11111"
+            bg={isDark ? '#1f1f1e' : 'white'}
+            borderRadius={'md'}
+            p={5}
+            boxShadow="lg"
+            maxW="sm"
+            minW="300px"
+        >
+            <TransactionToastContent
+                status={status}
+                txReceipt={txReceipt}
+                txError={txError}
+                onTryAgain={onTryAgain}
+                description={description}
+                onClose={onClose}
+            />
+        </Box>
     );
 };

--- a/packages/vechain-kit/src/components/WalletButton/WalletButton.tsx
+++ b/packages/vechain-kit/src/components/WalletButton/WalletButton.tsx
@@ -9,7 +9,7 @@ import { ConnectModal, AccountModal } from '@/components';
 import { ConnectedWallet } from './ConnectedWallet';
 import { WalletDisplayVariant } from './types';
 import { useTranslation } from 'react-i18next';
-import { useVeChainKitConfig, VechainKitThemeProvider } from '@/providers';
+import { useVeChainKitConfig } from '@/providers';
 import { ConnectPopover } from '../ConnectModal';
 
 export type WalletButtonProps = {
@@ -26,7 +26,7 @@ export const WalletButton = ({
     connectionVariant = 'modal',
 }: WalletButtonProps) => {
     const { t } = useTranslation();
-    const { darkMode, loginMethods } = useVeChainKitConfig();
+    const { loginMethods } = useVeChainKitConfig();
 
     const hasOnlyDappKit =
         loginMethods?.length === 1 && loginMethods[0].method === 'dappkit';
@@ -52,7 +52,7 @@ export const WalletButton = ({
     };
 
     return (
-        <VechainKitThemeProvider darkMode={darkMode}>
+        <>
             {connection.isConnected && !!account ? (
                 <ConnectedWallet
                     mobileVariant={mobileVariant}
@@ -83,6 +83,6 @@ export const WalletButton = ({
                 isOpen={accountModal.isOpen}
                 onClose={accountModal.onClose}
             />
-        </VechainKitThemeProvider>
+        </>
     );
 };

--- a/packages/vechain-kit/src/components/common/BaseModal.tsx
+++ b/packages/vechain-kit/src/components/common/BaseModal.tsx
@@ -1,4 +1,3 @@
-import { VechainKitThemeProvider } from '@/providers';
 import {
     Modal,
     ModalContent,
@@ -7,7 +6,6 @@ import {
     useMediaQuery,
 } from '@chakra-ui/react';
 import { ReactNode } from 'react';
-import { useVeChainKitConfig } from '@/providers';
 
 type BaseModalProps = {
     isOpen: boolean;
@@ -40,7 +38,6 @@ export const BaseModal = ({
     isCloseable = true,
 }: BaseModalProps) => {
     const [isDesktop] = useMediaQuery('(min-width: 768px)');
-    const { darkMode } = useVeChainKitConfig();
 
     const modalContentProps: ModalContentProps = isDesktop
         ? {}
@@ -56,31 +53,29 @@ export const BaseModal = ({
           };
 
     return (
-        <VechainKitThemeProvider darkMode={darkMode}>
-            <Modal
-                motionPreset={motionPreset}
-                isOpen={isOpen}
-                onClose={onClose}
-                isCentered={isCentered}
-                size={size}
-                // scrollBehavior="inside"
-                returnFocusOnClose={false}
-                blockScrollOnMount={blockScrollOnMount}
-                closeOnOverlayClick={closeOnOverlayClick && isCloseable}
-                preserveScrollBarGap={true}
-                portalProps={{ containerRef: undefined }}
-                trapFocus={!allowExternalFocus}
-                autoFocus={!allowExternalFocus}
+        <Modal
+            motionPreset={motionPreset}
+            isOpen={isOpen}
+            onClose={onClose}
+            isCentered={isCentered}
+            size={size}
+            // scrollBehavior="inside"
+            returnFocusOnClose={false}
+            blockScrollOnMount={blockScrollOnMount}
+            closeOnOverlayClick={closeOnOverlayClick && isCloseable}
+            preserveScrollBarGap={true}
+            portalProps={{ containerRef: undefined }}
+            trapFocus={!allowExternalFocus}
+            autoFocus={!allowExternalFocus}
+        >
+            <ModalOverlay backdropFilter={backdropFilter} />
+            <ModalContent
+                role="dialog"
+                aria-modal={!allowExternalFocus}
+                {...modalContentProps}
             >
-                <ModalOverlay backdropFilter={backdropFilter} />
-                <ModalContent
-                    role="dialog"
-                    aria-modal={!allowExternalFocus}
-                    {...modalContentProps}
-                >
-                    {children}
-                </ModalContent>
-            </Modal>
-        </VechainKitThemeProvider>
+                {children}
+            </ModalContent>
+        </Modal>
     );
 };

--- a/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
+++ b/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
@@ -36,6 +36,7 @@ import {
 import { Certificate, CertificateData } from '@vechain/sdk-core';
 import { PrivyCrossAppProvider } from './PrivyCrossAppProvider';
 import { PrivyWalletProvider } from './PrivyWalletProvider';
+import { VechainKitThemeProvider } from './VechainKitThemeProvider';
 
 type AlwaysAvailableMethods = 'vechain' | 'dappkit' | 'ecosystem';
 type PrivyDependentMethods = 'email' | 'google' | 'passkey' | 'more';
@@ -341,102 +342,111 @@ export const VeChainKitProvider = (
                         defaultCurrency,
                     }}
                 >
-                    <PrivyProvider
-                        appId={privyAppId}
-                        clientId={privyClientId}
-                        config={{
-                            // loginMethods: privy?.loginMethods,
-                            loginMethodsAndOrder: {
-                                primary: (privy?.loginMethods.slice(0, 4) ??
-                                    []) as NonEmptyArray<LoginMethodOrderOption>,
-                                overflow: (privy?.loginMethods.slice(4) ??
-                                    []) as Array<LoginMethodOrderOption>,
-                            },
-                            externalWallets: {
-                                walletConnect: {
-                                    enabled: false,
+                    <VechainKitThemeProvider darkMode={darkMode}>
+                        <PrivyProvider
+                            appId={privyAppId}
+                            clientId={privyClientId}
+                            config={{
+                                // loginMethods: privy?.loginMethods,
+                                loginMethodsAndOrder: {
+                                    primary: (privy?.loginMethods.slice(0, 4) ??
+                                        []) as NonEmptyArray<LoginMethodOrderOption>,
+                                    overflow: (privy?.loginMethods.slice(4) ??
+                                        []) as Array<LoginMethodOrderOption>,
                                 },
-                            },
-                            appearance: {
-                                theme: darkMode ? 'dark' : 'light',
-                                accentColor:
-                                    privy?.appearance.accentColor ??
-                                    (darkMode ? '#3182CE' : '#2B6CB0'),
-                                loginMessage: privy?.appearance.loginMessage,
-                                logo: privy?.appearance.logo,
-                            },
-                            embeddedWallets: {
-                                createOnLogin:
-                                    privy?.embeddedWallets?.createOnLogin ??
-                                    'all-users',
-                            },
-                            passkeys: {
-                                shouldUnlinkOnUnenrollMfa: false,
-                            },
-                        }}
-                    >
-                        <DAppKitProvider
-                            node={
-                                network.nodeUrl ??
-                                getConfig(network.type).nodeUrl
-                            }
-                            i18n={i18nConfig}
-                            language={language}
-                            logLevel={dappKit.logLevel}
-                            modalParent={dappKit.modalParent}
-                            onSourceClick={dappKit.onSourceClick}
-                            usePersistence={dappKit.usePersistence ?? true}
-                            allowedWallets={dappKit.allowedWallets}
-                            walletConnectOptions={dappKit.walletConnectOptions}
-                            themeMode={darkMode ? 'DARK' : 'LIGHT'}
-                            themeVariables={{
-                                '--vdk-modal-z-index': '10000',
-                                '--vdk-modal-width': '22rem',
-                                '--vdk-modal-backdrop-filter': 'blur(3px)',
-                                '--vdk-border-dark-source-card': `1px solid ${'#ffffff0a'}`,
-                                '--vdk-border-light-source-card': `1px solid ${'#ebebeb'}`,
-
-                                // Dark mode colors
-                                '--vdk-color-dark-primary': 'transparent',
-                                '--vdk-color-dark-primary-hover':
-                                    'rgba(255, 255, 255, 0.05)',
-                                '--vdk-color-dark-primary-active':
-                                    'rgba(255, 255, 255, 0.1)',
-                                '--vdk-color-dark-secondary': '#1f1f1e',
-
-                                // Light mode colors
-                                '--vdk-color-light-primary': '#ffffff',
-                                '--vdk-color-light-primary-hover': '#f8f8f8',
-                                '--vdk-color-light-primary-active': '#f0f0f0',
-                                '--vdk-color-light-secondary': 'white',
-
-                                // Font settings - using system fonts instead of Chakra variables
-                                '--vdk-font-family':
-                                    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-                                '--vdk-font-size-medium': '14px',
-                                '--vdk-font-size-large': '16px',
-                                '--vdk-font-weight-medium': '500',
+                                externalWallets: {
+                                    walletConnect: {
+                                        enabled: false,
+                                    },
+                                },
+                                appearance: {
+                                    theme: darkMode ? 'dark' : 'light',
+                                    accentColor:
+                                        privy?.appearance.accentColor ??
+                                        (darkMode ? '#3182CE' : '#2B6CB0'),
+                                    loginMessage:
+                                        privy?.appearance.loginMessage,
+                                    logo: privy?.appearance.logo,
+                                },
+                                embeddedWallets: {
+                                    createOnLogin:
+                                        privy?.embeddedWallets?.createOnLogin ??
+                                        'all-users',
+                                },
+                                passkeys: {
+                                    shouldUnlinkOnUnenrollMfa: false,
+                                },
                             }}
                         >
-                            <PrivyWalletProvider
-                                nodeUrl={
+                            <DAppKitProvider
+                                node={
                                     network.nodeUrl ??
                                     getConfig(network.type).nodeUrl
                                 }
-                                delegatorUrl={feeDelegation?.delegatorUrl ?? ''}
-                                delegateAllTransactions={
-                                    feeDelegation?.delegateAllTransactions ??
-                                    false
+                                i18n={i18nConfig}
+                                language={language}
+                                logLevel={dappKit.logLevel}
+                                modalParent={dappKit.modalParent}
+                                onSourceClick={dappKit.onSourceClick}
+                                usePersistence={dappKit.usePersistence ?? true}
+                                allowedWallets={dappKit.allowedWallets}
+                                walletConnectOptions={
+                                    dappKit.walletConnectOptions
                                 }
+                                themeMode={darkMode ? 'DARK' : 'LIGHT'}
+                                themeVariables={{
+                                    '--vdk-modal-z-index': '10000',
+                                    '--vdk-modal-width': '22rem',
+                                    '--vdk-modal-backdrop-filter': 'blur(3px)',
+                                    '--vdk-border-dark-source-card': `1px solid ${'#ffffff0a'}`,
+                                    '--vdk-border-light-source-card': `1px solid ${'#ebebeb'}`,
+
+                                    // Dark mode colors
+                                    '--vdk-color-dark-primary': 'transparent',
+                                    '--vdk-color-dark-primary-hover':
+                                        'rgba(255, 255, 255, 0.05)',
+                                    '--vdk-color-dark-primary-active':
+                                        'rgba(255, 255, 255, 0.1)',
+                                    '--vdk-color-dark-secondary': '#1f1f1e',
+
+                                    // Light mode colors
+                                    '--vdk-color-light-primary': '#ffffff',
+                                    '--vdk-color-light-primary-hover':
+                                        '#f8f8f8',
+                                    '--vdk-color-light-primary-active':
+                                        '#f0f0f0',
+                                    '--vdk-color-light-secondary': 'white',
+
+                                    // Font settings - using system fonts instead of Chakra variables
+                                    '--vdk-font-family':
+                                        'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+                                    '--vdk-font-size-medium': '14px',
+                                    '--vdk-font-size-large': '16px',
+                                    '--vdk-font-weight-medium': '500',
+                                }}
                             >
-                                <ModalProvider>
-                                    <LegalDocumentsProvider>
-                                        {children}
-                                    </LegalDocumentsProvider>
-                                </ModalProvider>
-                            </PrivyWalletProvider>
-                        </DAppKitProvider>
-                    </PrivyProvider>
+                                <PrivyWalletProvider
+                                    nodeUrl={
+                                        network.nodeUrl ??
+                                        getConfig(network.type).nodeUrl
+                                    }
+                                    delegatorUrl={
+                                        feeDelegation?.delegatorUrl ?? ''
+                                    }
+                                    delegateAllTransactions={
+                                        feeDelegation?.delegateAllTransactions ??
+                                        false
+                                    }
+                                >
+                                    <ModalProvider>
+                                        <LegalDocumentsProvider>
+                                            {children}
+                                        </LegalDocumentsProvider>
+                                    </ModalProvider>
+                                </PrivyWalletProvider>
+                            </DAppKitProvider>
+                        </PrivyProvider>
+                    </VechainKitThemeProvider>
                 </VeChainKitContext.Provider>
             </PrivyCrossAppProvider>
         </EnsureQueryClient>


### PR DESCRIPTION
### Description

In current version, theme provider is used in 4 places, 3 of them in components as wrapper and one as actual theme provider. This causes to inject scripts 4 times in any app that kit used. See below how it looks in VBD 👇🏼  To prevent this, theme provider is used only below VechainKitProvider. 

This will decrease also bundle size in any app used `kit`, I suppose.

<img width="700" height="auto" alt="image" src="https://github.com/user-attachments/assets/a0f74305-912b-46e6-af95-11429a8ef253" />

---

this is how it looks like in example/homepage current version

<img width="700" height="auto" alt="image" src="https://github.com/user-attachments/assets/1edb9383-61ba-4ecb-a035-90b16dd67fc4" />

and this is how it looks in preview url below

<img width="700" height="auto" alt="image" src="https://github.com/user-attachments/assets/cc8a3d9c-b7a4-4cfc-a811-5e83398b73a7" />



### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [x] vechain-kit
-   [ ] contracts
