### PR TITLE
fix: theme switch color mode

### DIFF
--- a/packages/vechain-kit/src/providers/VechainKitThemeProvider.tsx
+++ b/packages/vechain-kit/src/providers/VechainKitThemeProvider.tsx
@@ -6,7 +6,7 @@ import {
 import { CacheProvider, Global, css } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { ReactNode, useMemo } from 'react';
-import { VechainKitTheme } from '@/theme';
+import { getVechainKitTheme } from '@/theme';
 import { safeQuerySelector } from '@/utils/ssrUtils';
 
 type Props = {
@@ -95,9 +95,9 @@ export const VechainKitThemeProvider = ({
 }: Props) => {
     const theme = useMemo(
         () => ({
-            ...VechainKitTheme,
+            ...getVechainKitTheme(darkMode),
             config: {
-                ...VechainKitTheme.config,
+                ...getVechainKitTheme(darkMode).config,
                 initialColorMode: darkMode ? 'dark' : 'light',
             },
         }),

--- a/packages/vechain-kit/src/theme/card.ts
+++ b/packages/vechain-kit/src/theme/card.ts
@@ -1,75 +1,63 @@
 import { cardAnatomy } from '@chakra-ui/anatomy';
-import {
-    StyleFunctionProps,
-    createMultiStyleConfigHelpers,
-} from '@chakra-ui/react';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
 
 const { definePartsStyle, defineMultiStyleConfig } =
     createMultiStyleConfigHelpers(cardAnatomy.keys);
 
-const variants = {
-    vechainKitBase: (props: StyleFunctionProps) =>
-        definePartsStyle({
-            container: {
-                backgroundColor:
-                    props.colorMode === 'dark' ? '#1c1c1b' : '#f5f5f5',
-                borderRadius: '14px',
-                width: 'full',
-                border: 'none',
-            },
-            body: {
-                p: 5,
-                width: 'full',
-            },
-            header: {
-                p: 5,
-                width: 'full',
-                borderRadius: '14px 14px 0 0',
-            },
-            footer: {
-                width: 'full',
-                borderRadius: '0 0 14px 14px',
-            },
-        }),
+const getCardVariants = (darkMode: boolean) => ({
+    vechainKitBase: definePartsStyle({
+        container: {
+            backgroundColor: darkMode ? '#1c1c1b' : '#f5f5f5',
+            borderRadius: '14px',
+            width: 'full',
+            border: 'none',
+        },
+        body: {
+            p: 5,
+            width: 'full',
+        },
+        header: {
+            p: 5,
+            width: 'full',
+            borderRadius: '14px 14px 0 0',
+        },
+        footer: {
+            width: 'full',
+            borderRadius: '0 0 14px 14px',
+        },
+    }),
 
-    featureAnnouncement: (props: StyleFunctionProps) =>
-        definePartsStyle({
-            body: {
-                backgroundColor:
-                    props.colorMode === 'dark' ? '#ffffff0a' : 'blackAlpha.50',
-                borderRadius: '12px',
-                color:
-                    props.colorMode === 'dark' ? '#ffffff12' : 'blackAlpha.200',
-            },
-            container: {
-                borderRadius: '12px',
-                backgroundColor: 'transparent',
-            },
-        }),
+    featureAnnouncement: definePartsStyle({
+        body: {
+            backgroundColor: darkMode ? '#ffffff0a' : 'blackAlpha.50',
+            borderRadius: '12px',
+            color: darkMode ? '#ffffff12' : 'blackAlpha.200',
+        },
+        container: {
+            borderRadius: '12px',
+            backgroundColor: 'transparent',
+        },
+    }),
 
-    vechainKitAppCard: (props: StyleFunctionProps) =>
-        definePartsStyle({
-            body: {
-                height: 'full',
-                borderRadius: '12px',
-                backgroundColor:
-                    props.colorMode === 'dark' ? '#1f1f1e' : 'white',
-                border:
-                    props.colorMode === 'dark'
-                        ? '1px solid #2d2d2d'
-                        : '1px solid #eaeaea',
-            },
-            container: {
-                height: '150px',
-                borderRadius: '12px',
-                backgroundColor: 'transparent',
-            },
-        }),
-};
-
-export const cardTheme = defineMultiStyleConfig({
-    variants,
-    defaultProps: {
-        variant: 'vechainKitBase', // default is solid
-    },
+    vechainKitAppCard: definePartsStyle({
+        body: {
+            height: 'full',
+            borderRadius: '12px',
+            backgroundColor: darkMode ? '#1f1f1e' : 'white',
+            border: darkMode ? '1px solid #2d2d2d' : '1px solid #eaeaea',
+        },
+        container: {
+            height: '150px',
+            borderRadius: '12px',
+            backgroundColor: 'transparent',
+        },
+    }),
 });
+
+export const getCardTheme = (darkMode: boolean) =>
+    defineMultiStyleConfig({
+        variants: getCardVariants(darkMode),
+        defaultProps: {
+            variant: 'vechainKitBase', // default is solid
+        },
+    });

--- a/packages/vechain-kit/src/theme/modal.ts
+++ b/packages/vechain-kit/src/theme/modal.ts
@@ -1,64 +1,36 @@
 import { modalAnatomy as parts } from '@chakra-ui/anatomy';
-import {
-    StyleFunctionProps,
-    createMultiStyleConfigHelpers,
-} from '@chakra-ui/react';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
 
 const { definePartsStyle, defineMultiStyleConfig } =
     createMultiStyleConfigHelpers(parts.keys);
 
-const variants = {
-    vechainKitBase: (props: StyleFunctionProps) =>
-        definePartsStyle({
-            dialog: {
-                scrollbarWidth: 'none',
-                overflow: 'scroll',
-                overflowX: 'hidden',
-                maxHeight: '550px',
-                borderRadius: '24px',
-                backgroundColor:
-                    props.colorMode === 'dark' ? '#1f1f1e' : 'white',
-            },
-            closeButton: {
-                borderRadius: '50%',
-            },
-            header: {
-                w: 'full',
-                color: props.colorMode === 'dark' ? '#dfdfdd' : '#2e2e2e',
-                fontSize: 'md',
-                fontWeight: '700',
-                textAlign: 'center',
-            },
-        }),
-    vechainKitTransactionToast: (props: StyleFunctionProps) =>
-        definePartsStyle({
-            dialog: {
-                borderRadius: '15px',
-                position: 'fixed',
-                bottom: '10px',
-                left: '10px',
-                mimHeight: '70px',
-                minWidth: '300px',
-                maxWidth: '400px',
-                width: 'fit-content',
-                pointerEvents: 'auto',
-                boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.1)',
-                py: '10px',
-                backgroundColor:
-                    props.colorMode === 'dark' ? '#1f1f1e' : 'white',
-            },
-            closeButton: {
-                borderRadius: '50%',
-                width: '25px',
-                height: '25px',
-                size: '10px',
-            },
-        }),
-};
-
-export const modalTheme = defineMultiStyleConfig({
-    variants,
-    defaultProps: {
-        variant: 'vechainKitBase',
-    },
+const getModalVariants = (darkMode: boolean) => ({
+    vechainKitBase: definePartsStyle({
+        dialog: {
+            scrollbarWidth: 'none',
+            overflow: 'scroll',
+            overflowX: 'hidden',
+            maxHeight: '550px',
+            borderRadius: '24px',
+            backgroundColor: darkMode ? '#1f1f1e' : 'white',
+        },
+        closeButton: {
+            borderRadius: '50%',
+        },
+        header: {
+            w: 'full',
+            color: darkMode ? '#dfdfdd' : '#2e2e2e',
+            fontSize: 'md',
+            fontWeight: '700',
+            textAlign: 'center',
+        },
+    }),
 });
+
+export const getModalTheme = (darkMode: boolean) =>
+    defineMultiStyleConfig({
+        variants: getModalVariants(darkMode),
+        defaultProps: {
+            variant: 'vechainKitBase',
+        },
+    });

--- a/packages/vechain-kit/src/theme/popover.ts
+++ b/packages/vechain-kit/src/theme/popover.ts
@@ -1,35 +1,31 @@
 import { popoverAnatomy as parts } from '@chakra-ui/anatomy';
-import {
-    StyleFunctionProps,
-    createMultiStyleConfigHelpers,
-} from '@chakra-ui/react';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
 
 const { definePartsStyle, defineMultiStyleConfig } =
     createMultiStyleConfigHelpers(parts.keys);
 
-const variants = {
-    vechainKitBase: (props: StyleFunctionProps) =>
-        definePartsStyle({
-            popper: {
-                zIndex: 1000,
-            },
-            content: {
-                borderRadius: '24px',
-                border: 'none',
-                backgroundColor:
-                    props.colorMode === 'dark' ? '#1f1f1e' : 'white',
-                boxShadow: '0px 4px 16px rgba(0, 0, 0, 0.12)',
-                minWidth: '380px',
-            },
-            body: {
-                padding: '16px',
-            },
-        }),
-};
-
-export const popoverTheme = defineMultiStyleConfig({
-    variants,
-    defaultProps: {
-        variant: 'vechainKitBase',
-    },
+const getPopoverVariants = (darkMode: boolean) => ({
+    vechainKitBase: definePartsStyle({
+        popper: {
+            zIndex: 1000,
+        },
+        content: {
+            borderRadius: '24px',
+            border: 'none',
+            backgroundColor: darkMode ? '#1f1f1e' : 'white',
+            boxShadow: '0px 4px 16px rgba(0, 0, 0, 0.12)',
+            minWidth: '380px',
+        },
+        body: {
+            padding: '16px',
+        },
+    }),
 });
+
+export const getPopoverTheme = (darkMode: boolean) =>
+    defineMultiStyleConfig({
+        variants: getPopoverVariants(darkMode),
+        defaultProps: {
+            variant: 'vechainKitBase',
+        },
+    });

--- a/packages/vechain-kit/src/theme/theme.tsx
+++ b/packages/vechain-kit/src/theme/theme.tsx
@@ -1,62 +1,67 @@
 import { ThemeConfig, extendTheme, theme as baseTheme } from '@chakra-ui/react';
-import { modalTheme } from './modal';
-import { cardTheme } from './card';
+import { getModalTheme } from './modal';
+import { getCardTheme } from './card';
 import { buttonTheme } from './button';
-import { popoverTheme } from './popover';
+import { getPopoverTheme } from './popover';
 
 // minimal theme that completely disables global styles
-const themeConfig: ThemeConfig = {
-    useSystemColorMode: false,
-    disableTransitionOnChange: false,
+const getThemeConfig = (darkMode: boolean): ThemeConfig => ({
+  useSystemColorMode: false,
+  disableTransitionOnChange: false,
 
-    // @ts-ignore
-    components: {
-        Modal: modalTheme,
-        Card: cardTheme,
-        Button: buttonTheme,
-        Popover: popoverTheme,
+  // @ts-ignore
+  components: {
+    Modal: getModalTheme(darkMode),
+    Card: getCardTheme(darkMode),
+    Button: buttonTheme,
+    Popover: getPopoverTheme(darkMode),
+  },
+  cssVarPrefix: 'vechain-kit', // consistent naming across all components
+
+  // COMPLETELY disable global styles to prevent any conflicts
+  styles: {
+    global: () => ({}), // empty object = no global styles injected
+  },
+
+  // only defining the semantic tokens we need, scoped to our components
+  semanticTokens: {
+    colors: {
+      'chakra-body-text': {
+        _light: '#1A202C',
+        _dark: '#F7FAFC',
+      },
+      'chakra-body-bg': {
+        _light: '#FFFFFF',
+        _dark: '#1A202C',
+      },
+      'chakra-border-color': {
+        _light: '#E2E8F0',
+        _dark: '#2D3748',
+      },
+      'chakra-placeholder-color': {
+        _light: '#A0AEC0',
+        _dark: '#718096',
+      },
     },
-    cssVarPrefix: 'vechain-kit', // consistent naming across all components
+  },
 
-    // COMPLETELY disable global styles to prevent any conflicts
-    styles: {
-        global: () => ({}), // empty object = no global styles injected
-    },
+  // minimal foundations to prevent global style injection
+  fonts: baseTheme.fonts,
+  colors: baseTheme.colors,
+  space: baseTheme.space,
+});
 
-    // only defining the semantic tokens we need, scoped to our components
-    semanticTokens: {
-        colors: {
-            'chakra-body-text': {
-                _light: '#1A202C',
-                _dark: '#F7FAFC',
-            },
-            'chakra-body-bg': {
-                _light: '#FFFFFF',
-                _dark: '#1A202C',
-            },
-            'chakra-border-color': {
-                _light: '#E2E8F0',
-                _dark: '#2D3748',
-            },
-            'chakra-placeholder-color': {
-                _light: '#A0AEC0',
-                _dark: '#718096',
-            },
-        },
-    },
+export const getVechainKitTheme = (darkMode: boolean) => {
+  const theme = extendTheme(getThemeConfig(darkMode));
 
-    // minimal foundations to prevent global style injection
-    fonts: baseTheme.fonts,
-    colors: baseTheme.colors,
-    space: baseTheme.space,
+  // CRITICAL: Force override of global styles after theme creation
+  theme.styles.global = () => ({});
+
+  // also override any other global style fns that might exist
+  if (theme.__cssVars) {
+    theme.__cssVars.global = () => ({});
+  }
+
+  return theme;
 };
 
-export const VechainKitTheme = extendTheme(themeConfig);
-
-// CRITICAL: Force override of global styles after theme creation
-VechainKitTheme.styles.global = () => ({});
-
-// also override any other global style fns that might exist
-if (VechainKitTheme.__cssVars) {
-    VechainKitTheme.__cssVars.global = () => ({});
-}


### PR DESCRIPTION
### Description

This change is needed for users do not use chakra ui v2 at all. 

```
 vechainKitBase: (props: StyleFunctionProps) =>
```

this usage doesn't trigger if user does not use chakra v2, hence we should change the theme color changes according to the `darkMode` prop of vechainkit provider that we have.


Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [x] vechain-kit
-   [ ] contracts
