### PR TITLE
Publish to npmjs using OIDC

### DIFF
--- a/.github/workflows/publish-vechain-kit.yaml
+++ b/.github/workflows/publish-vechain-kit.yaml
@@ -24,7 +24,7 @@ jobs:
                   registry-url: https://npm.pkg.github.com/
                   cache: 'yarn'
 
-            - run: npm install -g npm@latest
+            - run: npm install -g npm@11.5.1
 
             - run: yarn && yarn install:all
 


### PR DESCRIPTION
### Description
Updated `publish-vechain-kit.yaml` to use OIDC

Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [ ] vechain-kit
-   [ ] contracts
