### PR TITLE
Change registry url

### DIFF
--- a/.github/workflows/publish-vechain-kit.yaml
+++ b/.github/workflows/publish-vechain-kit.yaml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20
-                  registry-url: https://npm.pkg.github.com/
+                  registry-url: https://registry.npmjs.org
                   cache: 'yarn'
 
             - run: npm install -g npm@11.5.1


### PR DESCRIPTION
### Description

Changing registry url as I suspect this is the reason we cannot use oidc to publish the package

Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [ ] vechain-kit
-   [ ] contracts
