### PR TITLE
Deploy to both npmjs and GPR

### DIFF
--- a/.github/workflows/publish-vechain-kit.yaml
+++ b/.github/workflows/publish-vechain-kit.yaml
@@ -18,7 +18,8 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
+            - name: Setup Node.js for GitHub Packages
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   registry-url: https://npm.pkg.github.com
@@ -32,10 +33,23 @@ jobs:
               env:
                   NODE_OPTIONS: '--max-old-space-size=4096'
 
-            - name: Publish VeChain-Kit
+            - name: Publish VeChain-Kit to GitHub Packages
               run: |
                   cd packages/vechain-kit
                   yarn version --immediate ${{ github.ref_name }}
                   npm publish --tag latest
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js for npmjs.org
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  registry-url: https://registry.npmjs.org
+                  cache: 'yarn'
+
+            - name: Publish VeChain-Kit to npmjs.org
+              run: |
+                  cd packages/vechain-kit
+                  yarn version --immediate ${{ github.ref_name }}
+                  npm publish --tag latest

--- a/.github/workflows/publish-vechain-kit.yaml
+++ b/.github/workflows/publish-vechain-kit.yaml
@@ -11,7 +11,7 @@ permissions:
     id-token: write # Required for OIDC
 
 jobs:
-    publish:
+    publish-to-github-packages:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -41,12 +41,27 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    publish-to-npmjs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
             - name: Setup Node.js for npmjs.org
               uses: actions/setup-node@v4
               with:
                   node-version: 20
                   registry-url: https://registry.npmjs.org
                   cache: 'yarn'
+
+            - run: npm install -g npm@11.5.1
+
+            - run: yarn && yarn install:all
+
+            - run: yarn build
+              env:
+                NODE_OPTIONS: '--max-old-space-size=4096'
 
             - name: Publish VeChain-Kit to npmjs.org
               run: |


### PR DESCRIPTION
### Description

Need to have 2 jobs in order to be able to publish to both npmjs and Github Package Registry, tested locally and seems to work

Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [ ] vechain-kit
-   [ ] contracts
