### PR TITLE
feat: use pull_request_target

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,7 +1,7 @@
 name: Deploy Preview Environment
 
 on:
-    pull_request:
+    pull_request_target:
         branches:
             - main
         paths: ['examples/homepage/**', 'packages/vechain-kit/**', 'yarn.lock']
@@ -26,6 +26,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Process Branch Name
               id: process-branch-name

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
 
 jobs:
     sonar-scan:
@@ -15,6 +15,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                   fetch-depth: 0
+                  ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
             - name: Cache SonarCloud packages
               uses: actions/cache@v4


### PR DESCRIPTION
### Description

When GHA's run on a PR from a fork, they run in the context of the PR source, so secrets are not exposed.

`on: pull_request` it runs in context of the fork where the PR is coming from, whereas if you use `pull_request_target` it should run in the base repo context where secrets are available (https://community.sonarsource.com/t/configuring-a-secured-github-workflow-to-launch-a-sonar-analysis-for-pr-from-forks/141898/9)

⚠️ Important Security Consideration
With pull_request_target, the workflow now has access to secrets while running code from the PR (including forks). 
This means:
1. Risk: A malicious contributor could potentially exfiltrate secrets through build scripts or package.json scripts during yarn install or yarn build
2. Mitigation options your DevOps team might want to consider:
- Manual approval: Require approval for first-time contributors (GitHub has built-in protection for this)
- Review before merge: Only maintainers should approve PRs after code review
- Branch restrictions: You could add a condition like if: github.event.pull_request.head.repo.full_name == github.repository to only auto-deploy PRs from the same repo (not forks)
- Two-step workflow: Build in one job without secrets, then deploy in another job with secrets using artifacts


Closes #(issue)

### Updated packages (if any):

-   [ ] next-template
-   [ ] homepage
-   [ ] vechain-kit
-   [ ] contracts
