### PR TITLE
Feat: Add bundle size diff checker

### DIFF
--- a/.github/workflows/build-size.yaml
+++ b/.github/workflows/build-size.yaml
@@ -6,7 +6,6 @@ on:
     types: [labeled, opened, synchronize, reopened]
     branches:
         - main
-        - chore/build-checker
 
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}-build-size


### PR DESCRIPTION
## Description

Adds automated GitHub Actions workflow to monitor and report bundle size changes for the `vechain-kit` package on pull requests.

### Changes

- **New workflow** (`.github/workflows/build-size.yaml`): Automated build size checking
- **Security**: Separate handling for internal vs external PRs - external PRs require `safe-to-build` label
- **Monitoring**: Tracks `packages/vechain-kit/dist/**/*` with 1KB minimum threshold
- **Reports**: Size differences posted directly in PR comments via `compressed-size-action`

### Updated packages:

- [x] vechain-kit
- [ ] next-template
- [ ] homepage
- [ ] contracts
