### PR TITLE
Fix: Remove border overrides

### DIFF
--- a/packages/vechain-kit/src/theme/theme.tsx
+++ b/packages/vechain-kit/src/theme/theme.tsx
@@ -35,10 +35,11 @@ const getThemeConfig = (
     // semantic tokens derived from ThemeTokens
     semanticTokens: {
         colors: {
-            // Note: chakra-body-text and chakra-body-bg are intentionally omitted
-            // to prevent Chakra UI from applying global body/html styles that would override host apps
-            // These are unset globally in VechainKitThemeProvider LayerSetup CSS
-            'chakra-border-color': tokens.colors.border.default,
+            // Note: chakra-body-text, chakra-body-bg, and chakra-border-color are intentionally omitted
+            // to prevent Chakra UI from applying global body/html/border styles that would override host apps
+            // Chakra injects: *, *::before, *::after { border-color: var(--chakra-colors-chakra-border-color) }
+            // which causes unwanted borders on consumer app elements (e.g., variant="link" buttons)
+            // Border colors are applied via scoped CSS in VechainKitThemeProvider LayerSetup instead
             'chakra-placeholder-color': tokens.colors.text.tertiary,
             // VeChain Kit semantic tokens
             // Main structural background tokens (for component backgrounds)
@@ -116,19 +117,12 @@ export const getVechainKitTheme = (
 
     const theme = extendTheme(themeConfig);
 
-    // CRITICAL: Override any global font CSS variables that Chakra might have created
-    // and ensure they don't leak to the host app
-    const originalGlobalStyles = theme.styles.global;
-    theme.styles.global = (props: any) => {
-        const originalStyles =
-            typeof originalGlobalStyles === 'function'
-                ? originalGlobalStyles(props)
-                : originalGlobalStyles || {};
-        return {
-            ...originalStyles,
-            // Don't set any global styles - fonts are handled via scoped CSS in VechainKitThemeProvider
-        };
-    };
+    // CRITICAL: Completely disable global styles to prevent Chakra from injecting
+    // *, *::before, *::after rules that would affect the consumer app
+    theme.styles.global = () => ({
+        // Return empty object - no global styles should leak to consumer app
+        // All VeChain Kit styles are scoped via LayerSetup in VechainKitThemeProvider
+    });
 
     // Override CSS variables to prevent them from being set globally
     // They will be set only within VeChain Kit containers via LayerSetup


### PR DESCRIPTION
### Description

Fixes CSS border override bug in consumer apps after upgrading VeChain Kit.

**Root Cause:**  
Chakra UI automatically injects `*, *::before, *::after { border-color: var(--chakra-colors-chakra-border-color) }` when the `chakra-border-color` semantic token is defined, affecting all elements in the consumer app.

**Solution:**  
Removed `chakra-border-color` from VeChain Kit's semantic tokens. Border colors are now applied only to VeChain Kit components via scoped CSS in `LayerSetup`.

### BEFORE
<img width="1268" height="1223" alt="Screenshot 2025-11-26 at 13 20 45" src="https://github.com/user-attachments/assets/e3d97a6c-fdd1-459f-acfb-cee94357bd1b" />


### AFTER
<img width="1277" height="1221" alt="Screenshot 2025-11-26 at 13 18 24" src="https://github.com/user-attachments/assets/20df97ff-5963-45d2-82d7-98f9ab3fcd53" />
