### PR TITLE
Only allow 1 preview workflow run

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -10,6 +10,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
     # Job 1: Post instruction comment for external PRs
     comment-external-pr:


### PR DESCRIPTION
* Added a `concurrency` group to `.github/workflows/deploy-preview.yaml` so that deploy preview jobs are grouped by pull request number, with `cancel-in-progress: true` to prevent overlapping deploys for the same PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment preview workflow to cancel redundant in-progress runs, improving resource efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->