### PR TITLE
fix: inline chakra theme helpers to avoid external resolution issues

### DIFF
--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -56,7 +56,6 @@
     },
     "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
-        "@chakra-ui/anatomy": "^2.3.6",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/styled": "^11.14.1",
         "@privy-io/cross-app-connect": "0.2.2",

--- a/packages/vechain-kit/src/theme/card.ts
+++ b/packages/vechain-kit/src/theme/card.ts
@@ -1,9 +1,14 @@
-import { cardAnatomy } from '@chakra-ui/anatomy';
-import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
 import { ThemeTokens } from './tokens';
 
-const { definePartsStyle, defineMultiStyleConfig } =
-    createMultiStyleConfigHelpers(cardAnatomy.keys);
+const CARD_ANATOMY_KEYS = ['container', 'header', 'body', 'footer'] as const;
+
+const definePartsStyle = <T>(config: T): T => config;
+const defineMultiStyleConfig = <T extends object>(
+    config: T,
+): T & { parts: readonly string[] } => ({
+    parts: CARD_ANATOMY_KEYS,
+    ...config,
+});
 
 const getCardVariants = (tokens: ThemeTokens) => ({
     vechainKitBase: definePartsStyle({

--- a/packages/vechain-kit/src/theme/modal.ts
+++ b/packages/vechain-kit/src/theme/modal.ts
@@ -1,9 +1,22 @@
-import { modalAnatomy as parts } from '@chakra-ui/anatomy';
-import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
 import { ThemeTokens } from './tokens';
 
-const { definePartsStyle, defineMultiStyleConfig } =
-    createMultiStyleConfigHelpers(parts.keys);
+const MODAL_ANATOMY_KEYS = [
+    'overlay',
+    'dialogContainer',
+    'dialog',
+    'header',
+    'closeButton',
+    'body',
+    'footer',
+] as const;
+
+const definePartsStyle = <T>(config: T): T => config;
+const defineMultiStyleConfig = <T extends object>(
+    config: T,
+): T & { parts: readonly string[] } => ({
+    parts: MODAL_ANATOMY_KEYS,
+    ...config,
+});
 
 const getModalVariants = (tokens: ThemeTokens) => ({
     vechainKitBase: definePartsStyle({

--- a/packages/vechain-kit/src/theme/popover.ts
+++ b/packages/vechain-kit/src/theme/popover.ts
@@ -1,9 +1,22 @@
-import { popoverAnatomy as parts } from '@chakra-ui/anatomy';
-import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
 import { ThemeTokens } from './tokens';
 
-const { definePartsStyle, defineMultiStyleConfig } =
-    createMultiStyleConfigHelpers(parts.keys);
+const POPOVER_ANATOMY_KEYS = [
+    'content',
+    'header',
+    'body',
+    'footer',
+    'popper',
+    'arrow',
+    'closeButton',
+] as const;
+
+const definePartsStyle = <T>(config: T): T => config;
+const defineMultiStyleConfig = <T extends object>(
+    config: T,
+): T & { parts: readonly string[] } => ({
+    parts: POPOVER_ANATOMY_KEYS,
+    ...config,
+});
 
 const getPopoverVariants = (tokens: ThemeTokens) => ({
     vechainKitBase: definePartsStyle({

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,7 +532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chakra-ui/anatomy@npm:2.3.6, @chakra-ui/anatomy@npm:^2.3.6":
+"@chakra-ui/anatomy@npm:2.3.6":
   version: 2.3.6
   resolution: "@chakra-ui/anatomy@npm:2.3.6"
   checksum: 10c0/36a6ffb4014d19e2db5893b43a3ca24868791a51dcb7c8ef872a81da97513a6b58162d66caf7271eb467d48b3582bd44ef3670668637709560317a59ff0ad219
@@ -7633,7 +7633,6 @@ __metadata:
   resolution: "@vechain/vechain-kit@workspace:packages/vechain-kit"
   dependencies:
     "@adraffy/ens-normalize": "npm:^1.11.0"
-    "@chakra-ui/anatomy": "npm:^2.3.6"
     "@chakra-ui/react": "npm:^2.8.2"
     "@emotion/styled": "npm:^11.14.1"
     "@privy-io/cross-app-connect": "npm:0.2.2"


### PR DESCRIPTION
## Summary

- Replaces `@chakra-ui/anatomy` imports and `createMultiStyleConfigHelpers` from `@chakra-ui/react` with inline equivalents in theme files (`card.ts`, `modal.ts`, `popover.ts`)
- The previous fix (#605) added `@chakra-ui/anatomy` as a dependency, but the root cause is that both `@chakra-ui/anatomy` and `createMultiStyleConfigHelpers` are externalized in the dist bundle via the tsdown config. This causes runtime errors (`createMultiStyleConfigHelpers is not a function`) in projects using Chakra UI v3 or Turbopack, where the bundler resolves `@chakra-ui/react` to v3 which lacks this v2-only API
- `createMultiStyleConfigHelpers` is an identity helper (`definePartsStyle` returns its argument, `defineMultiStyleConfig` adds a `parts` array). Inlining these eliminates the external dependency while preserving identical runtime behavior
- Removes the now-unnecessary `@chakra-ui/anatomy` dependency

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn build` succeeds
- [x] dist contains no references to `@chakra-ui/anatomy` or `createMultiStyleConfigHelpers`
- [ ] Verify a project using Chakra UI v3 + Turbopack (`next dev --turbo`) no longer errors

Made with [Cursor](https://cursor.com)