### PR TITLE
test: preview next-template for VeWorld signTypedData testing

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -5,7 +5,7 @@ on:
         types: [labeled, synchronize, opened, reopened]
         branches:
             - main
-        paths: ['examples/next-template/**', 'packages/vechain-kit/**', 'yarn.lock']
+        paths: ['examples/homepage/**', 'packages/vechain-kit/**', 'yarn.lock']
 
 permissions:
     contents: read
@@ -109,7 +109,7 @@ jobs:
 
             - name: Fix permissions
               run: |
-                  chmod -c -R +rX "./examples/next-template/dist" | while read line; do
+                  chmod -c -R +rX "./examples/homepage/dist" | while read line; do
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                   done
 
@@ -121,7 +121,7 @@ jobs:
 
             - name: Deploy to S3
               run: |
-                  aws s3 sync ./examples/next-template/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
+                  aws s3 sync ./examples/homepage/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
 
             - name: Cloudfront Invalidation
               run: |

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -5,7 +5,7 @@ on:
         types: [labeled, synchronize, opened, reopened]
         branches:
             - main
-        paths: ['examples/homepage/**', 'packages/vechain-kit/**', 'yarn.lock']
+        paths: ['examples/next-template/**', 'packages/vechain-kit/**', 'yarn.lock']
 
 permissions:
     contents: read
@@ -109,7 +109,7 @@ jobs:
 
             - name: Fix permissions
               run: |
-                  chmod -c -R +rX "./examples/homepage/dist" | while read line; do
+                  chmod -c -R +rX "./examples/next-template/dist" | while read line; do
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                   done
 
@@ -121,7 +121,7 @@ jobs:
 
             - name: Deploy to S3
               run: |
-                  aws s3 sync ./examples/homepage/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
+                  aws s3 sync ./examples/next-template/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
 
             - name: Cloudfront Invalidation
               run: |

--- a/examples/homepage/src/app/pages/Home.tsx
+++ b/examples/homepage/src/app/pages/Home.tsx
@@ -21,6 +21,7 @@ import { FAQSection } from '../components/features/FAQSection';
 import { QuickStartSection } from '../components/features/QuickStartSection';
 import { ScrollableInfoSections } from '@/app/components/features/ScrollableInfoSections';
 import { FloatingGetStartedButton } from '@/app/components/features/FloatingGetStartedButton/FloatingGetStartedButton';
+import { SigningExample } from '@/app/components/features/Signing';
 
 export default function Home(): ReactElement {
     const { colorMode } = useColorMode();
@@ -77,6 +78,16 @@ export default function Home(): ReactElement {
             />
 
             <AppShowcase />
+
+            <Card
+                variant="section"
+                py={{ base: 8, md: 12 }}
+                px={{ base: 4, md: 8 }}
+            >
+                <VStack spacing={4} align="center" maxW="4xl" mx="auto" w="full">
+                    <SigningExample />
+                </VStack>
+            </Card>
 
             <QuickStartSection />
 

--- a/examples/next-template/next.config.js
+++ b/examples/next-template/next.config.js
@@ -1,4 +1,4 @@
-const basePath = process.env.BASE_PATH ?? '';
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? '';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/packages/vechain-kit/src/hooks/signing/useSignTypedData.ts
+++ b/packages/vechain-kit/src/hooks/signing/useSignTypedData.ts
@@ -1,5 +1,6 @@
 'use client';
 
+// TODO: investigate signTypedData support in VeWorld in-app browser
 import { useCallback, useState } from 'react';
 import { SignTypedDataParams } from '@privy-io/react-auth';
 import { usePrivyWalletProvider } from '@/providers';


### PR DESCRIPTION
## Summary
- Switches the preview deployment from `examples/homepage` to `examples/next-template` so we can test `useSignTypedData` inside VeWorld's in-app browser
- Fixes `NEXT_PUBLIC_BASE_PATH` env var support in next-template's `next.config.js` (was only reading `BASE_PATH`)

## Context
A user reported that `useSignTypedData` works with Privy and VeWorld extension but fails inside VeWorld's in-app browser. The next-template example has a `SigningExample` component that exercises this exact flow — deploying it as a preview gives us a URL to open in VeWorld mobile.

## Test plan
- [ ] Open preview URL in VeWorld mobile in-app browser
- [ ] Connect wallet
- [ ] Tap "Sign Typed Data" and observe behavior
- [ ] Compare with VeWorld extension (should work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment preview workflow to monitor next-template example directories.
  * Modified base path configuration in Next.js template to prioritize updated environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->