### PR TITLE
feat: add contractAddresses override and restyle custom tokens UI

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -5,7 +5,7 @@ on:
         types: [labeled, synchronize, opened, reopened]
         branches:
             - main
-        paths: ['examples/next-template/**', 'packages/vechain-kit/**', 'yarn.lock']
+        paths: ['examples/homepage/**', 'packages/vechain-kit/**', 'yarn.lock']
 
 permissions:
     contents: read
@@ -109,7 +109,7 @@ jobs:
 
             - name: Fix permissions
               run: |
-                  chmod -c -R +rX "./examples/next-template/dist" | while read line; do
+                  chmod -c -R +rX "./examples/homepage/dist" | while read line; do
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                   done
 
@@ -121,7 +121,7 @@ jobs:
 
             - name: Deploy to S3
               run: |
-                  aws s3 sync ./examples/next-template/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
+                  aws s3 sync ./examples/homepage/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
 
             - name: Cloudfront Invalidation
               run: |

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -5,7 +5,7 @@ on:
         types: [labeled, synchronize, opened, reopened]
         branches:
             - main
-        paths: ['examples/homepage/**', 'packages/vechain-kit/**', 'yarn.lock']
+        paths: ['examples/next-template/**', 'packages/vechain-kit/**', 'yarn.lock']
 
 permissions:
     contents: read
@@ -109,7 +109,7 @@ jobs:
 
             - name: Fix permissions
               run: |
-                  chmod -c -R +rX "./examples/homepage/dist" | while read line; do
+                  chmod -c -R +rX "./examples/next-template/dist" | while read line; do
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                   done
 
@@ -121,7 +121,7 @@ jobs:
 
             - name: Deploy to S3
               run: |
-                  aws s3 sync ./examples/homepage/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
+                  aws s3 sync ./examples/next-template/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
 
             - name: Cloudfront Invalidation
               run: |

--- a/examples/homepage/src/app/pages/Home.tsx
+++ b/examples/homepage/src/app/pages/Home.tsx
@@ -21,6 +21,7 @@ import { FAQSection } from '../components/features/FAQSection';
 import { QuickStartSection } from '../components/features/QuickStartSection';
 import { ScrollableInfoSections } from '@/app/components/features/ScrollableInfoSections';
 import { FloatingGetStartedButton } from '@/app/components/features/FloatingGetStartedButton/FloatingGetStartedButton';
+import { SigningExample } from '@/app/components/features/Signing';
 
 export default function Home(): ReactElement {
     const { colorMode } = useColorMode();
@@ -77,6 +78,16 @@ export default function Home(): ReactElement {
             />
 
             <AppShowcase />
+
+            <Card
+                variant="section"
+                py={{ base: 8, md: 12 }}
+                px={{ base: 4, md: 8 }}
+            >
+                <VStack spacing={4} align="center" maxW="4xl" mx="auto" w="full">
+                    <SigningExample />
+                </VStack>
+            </Card>
 
             <QuickStartSection />
 

--- a/examples/next-template/next.config.js
+++ b/examples/next-template/next.config.js
@@ -1,4 +1,4 @@
-const basePath = process.env.BASE_PATH ?? '';
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? '';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/examples/playground/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/playground/src/app/providers/VechainKitProviderWrapper.tsx
@@ -226,12 +226,12 @@ export function VechainKitProviderWrapper({ children }: Props) {
                 // nodeUrl: 'http://localhost:8669',
             }}
             allowCustomTokens={true}
-            contractAddresses={{
-                b3trContractAddress:
-                    '0x026771d1be764467f8bdb78bb230df10c924b00d',
-                vot3ContractAddress:
-                    '0xf7a08af15cb3501feee53ebe11f4428a966fa459',
-            }}
+            // contractAddresses={{
+            //     b3trContractAddress:
+            //         '0x026771d1be764467f8bdb78bb230df10c924b00d',
+            //     vot3ContractAddress:
+            //         '0xf7a08af15cb3501feee53ebe11f4428a966fa459',
+            // }}
         >
             <LanguageSync>{children}</LanguageSync>
         </VeChainKitProvider>

--- a/examples/playground/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/playground/src/app/providers/VechainKitProviderWrapper.tsx
@@ -110,10 +110,13 @@ export function VechainKitProviderWrapper({ children }: Props) {
     }, [kitLanguage]);
 
     // Transform resources to match I18n type (extract translation objects)
-    const playgroundTranslations = Object.keys(resources).reduce((acc, lang) => {
-        acc[lang] = resources[lang as keyof typeof resources].translation;
-        return acc;
-    }, {} as Record<string, Record<string, string>>);
+    const playgroundTranslations = Object.keys(resources).reduce(
+        (acc, lang) => {
+            acc[lang] = resources[lang as keyof typeof resources].translation;
+            return acc;
+        },
+        {} as Record<string, Record<string, string>>,
+    );
 
     const theme = isDarkMode
         ? {
@@ -219,10 +222,16 @@ export function VechainKitProviderWrapper({ children }: Props) {
             ]}
             darkMode={isDarkMode}
             network={{
-                type: 'main',
+                type: 'test',
                 // nodeUrl: 'http://localhost:8669',
             }}
             allowCustomTokens={true}
+            contractAddresses={{
+                b3trContractAddress:
+                    '0x026771d1be764467f8bdb78bb230df10c924b00d',
+                vot3ContractAddress:
+                    '0xf7a08af15cb3501feee53ebe11f4428a966fa459',
+            }}
         >
             <LanguageSync>{children}</LanguageSync>
         </VeChainKitProvider>

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.6.9",
+    "version": "2.7.0",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Assets/AssetsContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Assets/AssetsContent.tsx
@@ -1,14 +1,14 @@
 import {
-    Button,
     Container,
-    Icon,
+    HStack,
+    IconButton,
     Input,
     InputGroup,
     InputLeftElement,
     ModalBody,
     ModalCloseButton,
-    ModalFooter,
     ModalHeader,
+    Tooltip,
     VStack,
     useToken,
 } from '@chakra-ui/react';
@@ -76,23 +76,42 @@ export const AssetsContent = ({ setCurrentContent }: AssetsContentProps) => {
 
             <Container h={['540px', 'auto']} p={0}>
                 <ModalBody>
-                    <InputGroup size="lg">
-                        <Input
-                            placeholder="Search token"
-                            bg={darkMode ? '#00000038' : 'gray.50'}
-                            borderRadius="xl"
-                            height="56px"
-                            pl={12}
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            data-testid="search-token-input"
-                        />
-                        <InputLeftElement h="56px" w="56px" pl={4}>
-                            <LuSearch
-                                color={textTertiary}
+                    <HStack spacing={2}>
+                        <InputGroup size="lg" flex={1}>
+                            <Input
+                                placeholder="Search token"
+                                bg={darkMode ? '#00000038' : 'gray.50'}
+                                borderRadius="xl"
+                                height="56px"
+                                pl={12}
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                data-testid="search-token-input"
                             />
-                        </InputLeftElement>
-                    </InputGroup>
+                            <InputLeftElement h="56px" w="56px" pl={4}>
+                                <LuSearch
+                                    color={textTertiary}
+                                />
+                            </InputLeftElement>
+                        </InputGroup>
+                        {allowCustomTokens && (
+                            <Tooltip label={t('Manage Custom Tokens')}>
+                                <IconButton
+                                    aria-label={t('Manage Custom Tokens')}
+                                    icon={<LuPencil />}
+                                    variant="vechainKitSecondary"
+                                    size="lg"
+                                    height="56px"
+                                    width="56px"
+                                    minW="56px"
+                                    borderRadius="xl"
+                                    onClick={() =>
+                                        setCurrentContent('add-custom-token')
+                                    }
+                                />
+                            </Tooltip>
+                        )}
+                    </HStack>
 
                     <VStack spacing={2} align="stretch" mt={2}>
                         {filteredTokens.map((token) => {
@@ -118,19 +137,6 @@ export const AssetsContent = ({ setCurrentContent }: AssetsContentProps) => {
                         })}
                     </VStack>
                 </ModalBody>
-                <ModalFooter>
-                    {allowCustomTokens && (
-                        <Button
-                            variant="vechainKitSecondary"
-                            leftIcon={<Icon as={LuPencil} boxSize={4} />}
-                            onClick={() =>
-                                setCurrentContent('add-custom-token')
-                            }
-                        >
-                            {t('Manage Custom Tokens')}
-                        </Button>
-                    )}
-                </ModalFooter>
             </Container>
         </>
     );

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Assets/ManageCustomTokenContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Assets/ManageCustomTokenContent.tsx
@@ -8,10 +8,9 @@ import {
     Text,
     Box,
     HStack,
-    ModalFooter,
     FormControl,
-    FormLabel,
     Image,
+    IconButton,
     useToken,
 } from '@chakra-ui/react';
 import { ModalBackButton, StickyHeaderContainer } from '@/components';
@@ -20,7 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { useCustomTokens } from '@/hooks/api/wallet/useCustomTokens';
 import { humanAddress, TOKEN_LOGOS } from '@/utils';
-import { LuTrash2 } from 'react-icons/lu';
+import { LuPlus, LuTrash2 } from 'react-icons/lu';
 
 export type ManageCustomTokenContentProps = {
     setCurrentContent: React.Dispatch<
@@ -82,7 +81,7 @@ export const ManageCustomTokenContent = ({
             await addToken(data.newTokenAddress);
             setValue('newTokenAddress', ''); // Clear the input after successful addition
         } catch (error) {
-            console.error('Error adding token 2:', error);
+            console.error('Error adding token:', error);
             setError('newTokenAddress', {
                 type: 'manual',
                 message: t('Invalid token address'),
@@ -99,45 +98,67 @@ export const ManageCustomTokenContent = ({
             </StickyHeaderContainer>
 
             <ModalBody>
-                <VStack spacing={4} align="stretch" position="relative">
+                <VStack spacing={4} align="stretch">
                     {/* Input Section */}
-                    <Box p={6} borderRadius="xl" bg={backgroundCard}>
-                        <VStack align="stretch" spacing={2}>
+                    <Box p={4} borderRadius="xl" bg={backgroundCard}>
+                        <VStack align="stretch" spacing={3}>
+                            <Text fontSize="sm" color={textSecondary}>
+                                {t(
+                                    'Paste a token contract address to track its balance in your wallet.',
+                                )}
+                            </Text>
                             <FormControl isInvalid={!!errors.newTokenAddress}>
-                                <FormLabel
-                                    fontSize="sm"
-                                    fontWeight="medium"
-                                    color={textPrimary}
-                                >
-                                    {t('Token Contract Address')}
-                                </FormLabel>
-                                <Input
-                                    {...register('newTokenAddress', {
-                                        required: t('Address is required'),
-                                        pattern: {
-                                            value: /^0x[a-fA-F0-9]{40}$/,
-                                            message: t(
-                                                'Please enter a valid contract address',
-                                            ),
-                                        },
-                                        validate: (value) =>
-                                            /^0x[a-fA-F0-9]{40}$/.test(value) ||
-                                            t('Invalid contract address'),
-                                    })}
-                                    onChange={(e) => {
-                                        const trimmed = e.target.value.trim();
-                                        e.target.value = trimmed;
-                                        setValue('newTokenAddress', trimmed, {
-                                            shouldValidate: true,
-                                        });
-                                    }}
-                                    placeholder="0x..."
-                                    variant="outline"
-                                    fontSize="md"
-                                    fontWeight="medium"
-                                />
+                                <HStack spacing={2}>
+                                    <Input
+                                        {...register('newTokenAddress', {
+                                            required: t('Address is required'),
+                                            pattern: {
+                                                value: /^0x[a-fA-F0-9]{40}$/,
+                                                message: t(
+                                                    'Please enter a valid contract address',
+                                                ),
+                                            },
+                                            validate: (value) =>
+                                                /^0x[a-fA-F0-9]{40}$/.test(
+                                                    value,
+                                                ) ||
+                                                t('Invalid contract address'),
+                                        })}
+                                        onChange={(e) => {
+                                            const trimmed =
+                                                e.target.value.trim();
+                                            e.target.value = trimmed;
+                                            setValue(
+                                                'newTokenAddress',
+                                                trimmed,
+                                                { shouldValidate: true },
+                                            );
+                                        }}
+                                        placeholder="0x..."
+                                        variant="outline"
+                                        fontSize="md"
+                                        fontWeight="medium"
+                                        flex={1}
+                                    />
+                                    <IconButton
+                                        aria-label={t('Add Token')}
+                                        icon={<LuPlus />}
+                                        variant="vechainKitPrimary"
+                                        size="md"
+                                        minW="40px"
+                                        w="40px"
+                                        h="40px"
+                                        borderRadius="lg"
+                                        isDisabled={!isValid}
+                                        onClick={handleSubmit(onSubmit)}
+                                    />
+                                </HStack>
                                 {errors.newTokenAddress && (
-                                    <Text color="#ef4444" fontSize="sm">
+                                    <Text
+                                        color="#ef4444"
+                                        fontSize="sm"
+                                        mt={1}
+                                    >
                                         {errors.newTokenAddress.message}
                                     </Text>
                                 )}
@@ -146,30 +167,36 @@ export const ManageCustomTokenContent = ({
                     </Box>
 
                     {/* Existing Tokens List */}
-                    {customTokens.length > 0 && (
-                        <Box p={4} borderRadius="xl" bg={backgroundOverlay}>
-                            <Text fontSize="sm" fontWeight="medium" mb={2}>
-                                {t('Existing Custom Tokens')}
-                            </Text>
+                    <Box>
+                        <Text
+                            fontSize="sm"
+                            fontWeight="medium"
+                            color={textSecondary}
+                            mb={2}
+                            px={1}
+                        >
+                            {t('Existing Custom Tokens')}
+                        </Text>
+                        {customTokens.length > 0 ? (
                             <VStack align="stretch" spacing={2}>
                                 {customTokens.map((token) => (
                                     <HStack
                                         key={token.address}
                                         justify="space-between"
                                         fontSize="sm"
-                                        p={2}
-                                        borderRadius="md"
-                                        bg={backgroundCard}
+                                        p={3}
+                                        borderRadius="xl"
+                                        bg={backgroundOverlay}
                                     >
-                                        <HStack>
+                                        <HStack spacing={3}>
                                             <Image
                                                 src={TOKEN_LOGOS[token?.symbol]}
                                                 alt={`${token.symbol} logo`}
-                                                boxSize="20px"
+                                                boxSize="28px"
                                                 borderRadius="full"
                                                 fallback={
                                                     <Box
-                                                        boxSize="20px"
+                                                        boxSize="28px"
                                                         borderRadius="full"
                                                         bg="whiteAlpha.200"
                                                         display="flex"
@@ -177,7 +204,7 @@ export const ManageCustomTokenContent = ({
                                                         justifyContent="center"
                                                     >
                                                         <Text
-                                                            fontSize="8px"
+                                                            fontSize="9px"
                                                             fontWeight="bold"
                                                             color={textPrimary}
                                                         >
@@ -189,52 +216,62 @@ export const ManageCustomTokenContent = ({
                                                     </Box>
                                                 }
                                             />
-                                            <Text
-                                                fontWeight="medium"
-                                                color={textPrimary}
+                                            <VStack
+                                                spacing={0}
+                                                align="start"
                                             >
-                                                {token.symbol ?? 'Unknown'}
-                                            </Text>
+                                                <Text
+                                                    fontWeight="medium"
+                                                    color={textPrimary}
+                                                    fontSize="sm"
+                                                >
+                                                    {token.symbol ?? 'Unknown'}
+                                                </Text>
+                                                <Text
+                                                    color={textSecondary}
+                                                    fontSize="xs"
+                                                >
+                                                    {humanAddress(
+                                                        token.address ?? '',
+                                                        6,
+                                                        4,
+                                                    )}
+                                                </Text>
+                                            </VStack>
                                         </HStack>
-                                        <Text color={textSecondary}>
-                                            {humanAddress(
-                                                token.address ?? '',
-                                                4,
-                                                4,
-                                            )}
-                                        </Text>
                                         <Button
                                             size="sm"
                                             variant="ghost"
-                                            color={textPrimary}
+                                            color={textSecondary}
                                             borderRadius="md"
                                             p={2}
                                             onClick={() =>
                                                 removeToken(token.address)
                                             }
                                         >
-                                            <LuTrash2
-                                                size={16}
-                                                color={textPrimary}
-                                            />
+                                            <LuTrash2 size={16} />
                                         </Button>
                                     </HStack>
                                 ))}
                             </VStack>
-                        </Box>
-                    )}
+                        ) : (
+                            <Box
+                                p={6}
+                                borderRadius="xl"
+                                bg={backgroundOverlay}
+                                textAlign="center"
+                            >
+                                <Text
+                                    fontSize="sm"
+                                    color={textSecondary}
+                                >
+                                    {t('No custom tokens added yet.')}
+                                </Text>
+                            </Box>
+                        )}
+                    </Box>
                 </VStack>
             </ModalBody>
-
-            <ModalFooter>
-                <Button
-                    variant="vechainKitPrimary"
-                    isDisabled={!isValid}
-                    onClick={handleSubmit(onSubmit)}
-                >
-                    {t('Add Token')}
-                </Button>
-            </ModalFooter>
         </>
     );
 };

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Swap/SwapTokenContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Swap/SwapTokenContent.tsx
@@ -41,7 +41,6 @@ import { SwapQuote } from '@/types/swap';
 import { useVeChainKitConfig } from '@/providers';
 import { TOKEN_LOGOS, TOKEN_LOGO_COMPONENTS } from '@/utils';
 import { formatUnits, parseUnits } from 'viem';
-import { getConfig } from '@/config';
 import { compareAddresses, NON_TRANSFERABLE_TOKEN_SYMBOLS } from '@/utils';
 import { SelectTokenContent } from '../SendToken/SelectTokenContent';
 import { formatCompactCurrency } from '@/utils/currencyUtils';
@@ -77,7 +76,7 @@ export const SwapTokenContent = ({
     const { t } = useTranslation();
     const { account, connection } = useWallet();
     const { currentCurrency } = useCurrency();
-    const { network, feeDelegation, darkMode: isDark } = useVeChainKitConfig();
+    const { network, feeDelegation, darkMode: isDark, appConfig } = useVeChainKitConfig();
     const { isolatedView, closeAccountModal } = useAccountModalOptions();
 
     const cardBg = useToken('colors', 'vechain-kit-card');
@@ -174,8 +173,7 @@ export const SwapTokenContent = ({
             // If not found by symbol, try finding by address from config
             if (!b3trToken) {
                 try {
-                    const config = getConfig(network.type);
-                    const b3trAddress = config.b3trContractAddress;
+                    const b3trAddress = appConfig.b3trContractAddress;
                     if (b3trAddress) {
                         b3trToken = sortedTokens.find((t) =>
                             compareAddresses(t.address, b3trAddress),
@@ -552,8 +550,7 @@ export const SwapTokenContent = ({
                 // If not found by symbol, try finding by address from config
                 if (!b3trToken) {
                     try {
-                        const config = getConfig(network.type);
-                        const b3trAddress = config.b3trContractAddress;
+                        const b3trAddress = appConfig.b3trContractAddress;
                         if (b3trAddress) {
                             b3trToken = sortedTokens.find((t) =>
                                 compareAddresses(t.address, b3trAddress),

--- a/packages/vechain-kit/src/hooks/api/wallet/useCustomTokens.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useCustomTokens.ts
@@ -1,7 +1,6 @@
 import { LocalStorageKey, useLocalStorage } from '@/hooks';
 import { compareAddresses } from '@/utils';
-import { useVeChainKitConfig } from '@/providers';
-import { getConfig } from '@/config';
+import { useAppConfig, useVeChainKitConfig } from '@/providers';
 import { type CustomTokenInfo } from '@vechain/contract-getters';
 
 import {  getTokenInfo } from './useGetCustomTokenInfo';
@@ -12,6 +11,7 @@ export const useCustomTokens = () => {
         [],
     );
     const { network } = useVeChainKitConfig();
+    const config = useAppConfig();
 
     const addToken = async (address: CustomTokenInfo['address']) => {
         if (!isTokenIncluded(address) && !isDefaultToken(address)) {
@@ -41,15 +41,15 @@ export const useCustomTokens = () => {
 
     const isDefaultToken = (address: string) => {
         // Get contract addresses from config
-        const contractAddresses = {
+        const defaultAddresses = {
             vet: '0x', // VET has no contract address since it's the native token
-            vtho: getConfig(network.type).vthoContractAddress,
-            b3tr: getConfig(network.type).b3trContractAddress,
-            vot3: getConfig(network.type).vot3ContractAddress,
-            veDelegate: getConfig(network.type).veDelegate,
+            vtho: config.vthoContractAddress,
+            b3tr: config.b3trContractAddress,
+            vot3: config.vot3ContractAddress,
+            veDelegate: config.veDelegate,
         };
 
-        return Object.values(contractAddresses).includes(address);
+        return Object.values(defaultAddresses).includes(address);
     };
 
     return {

--- a/packages/vechain-kit/src/hooks/api/wallet/useGetB3trBalance.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useGetB3trBalance.ts
@@ -1,7 +1,7 @@
-import { useVeChainKitConfig } from '@/providers';
+import { useAppConfig, useVeChainKitConfig } from '@/providers';
 import { formatTokenBalance } from '@/utils';
 import { useQuery } from '@tanstack/react-query';
-import { getB3trBalance } from '@vechain/contract-getters';
+import { getErc20Balance } from '@vechain/contract-getters';
 import { VECHAIN_KIT_QUERY_KEYS } from '@/constants/queryKeys';
 
 export const getB3trBalanceQueryKey = (address?: string) =>
@@ -9,14 +9,17 @@ export const getB3trBalanceQueryKey = (address?: string) =>
 
 export const useGetB3trBalance = (address?: string) => {
     const { network } = useVeChainKitConfig();
+    const { b3trContractAddress } = useAppConfig();
 
     return useQuery({
         queryKey: getB3trBalanceQueryKey(address),
         queryFn: async () => {
             if (!address) throw new Error('Address is required');
-            const res = await getB3trBalance(address, {
-                networkUrl: network.nodeUrl,
-            });
+            const res = await getErc20Balance(
+                b3trContractAddress,
+                address,
+                { networkUrl: network.nodeUrl },
+            );
 
             if (!res) throw new Error('Failed to get b3tr balance');
 

--- a/packages/vechain-kit/src/hooks/api/wallet/useGetVot3Balance.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useGetVot3Balance.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useVeChainKitConfig } from '@/providers';
+import { useAppConfig, useVeChainKitConfig } from '@/providers';
 import { formatTokenBalance } from '@/utils';
-import { getVot3Balance } from '@vechain/contract-getters';
+import { getErc20Balance } from '@vechain/contract-getters';
 import { VECHAIN_KIT_QUERY_KEYS } from '@/constants/queryKeys';
 
 export const getVot3BalanceQueryKey = (address?: string) =>
@@ -9,14 +9,17 @@ export const getVot3BalanceQueryKey = (address?: string) =>
 
 export const useGetVot3Balance = (address?: string) => {
     const { network } = useVeChainKitConfig();
+    const { vot3ContractAddress } = useAppConfig();
 
     return useQuery({
         queryKey: getVot3BalanceQueryKey(address),
         queryFn: async () => {
             if (!address) throw new Error('Address is required');
-            const res = await getVot3Balance(address, {
-                networkUrl: network.nodeUrl,
-            });
+            const res = await getErc20Balance(
+                vot3ContractAddress,
+                address,
+                { networkUrl: network.nodeUrl },
+            );
 
             if (!res) throw new Error('Failed to get vot3 balance');
 

--- a/packages/vechain-kit/src/hooks/api/wallet/useTokenBalances.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useTokenBalances.ts
@@ -6,8 +6,7 @@ import {
     useGetErc20Balance,
     useGetCustomTokenBalances,
 } from '@/hooks';
-import { useVeChainKitConfig } from '@/providers';
-import { getConfig } from '@/config';
+import { useAppConfig, useVeChainKitConfig } from '@/providers';
 
 export type WalletTokenBalance = {
     address: string;
@@ -17,7 +16,7 @@ export type WalletTokenBalance = {
 
 export const useTokenBalances = (address?: string) => {
     const { network, allowCommunityTokens } = useVeChainKitConfig();
-    const config = getConfig(network.type);
+    const config = useAppConfig();
 
     // Base token balances
     const { data: vetData, isLoading: vetLoading } = useAccountBalance(address);

--- a/packages/vechain-kit/src/hooks/api/wallet/useTokenPrices.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useTokenPrices.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
-import { useVeChainKitConfig } from '@/providers';
-import { getConfig } from '@/config';
+import { useAppConfig, useVeChainKitConfig } from '@/providers';
 import { useGetTokenUsdPrice } from './useGetTokenUsdPrice';
 
 export type ExchangeRates = {
@@ -10,7 +9,7 @@ export type ExchangeRates = {
 
 export const useTokenPrices = () => {
     const { network } = useVeChainKitConfig();
-    const config = getConfig(network.type);
+    const config = useAppConfig();
 
     // Fetch base token prices
     const { data: vetUsdPrice, isLoading: vetUsdPriceLoading } =

--- a/packages/vechain-kit/src/hooks/api/wallet/useTokenPrices.ts
+++ b/packages/vechain-kit/src/hooks/api/wallet/useTokenPrices.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useAppConfig, useVeChainKitConfig } from '@/providers';
+import { useAppConfig } from '@/providers';
 import { useGetTokenUsdPrice } from './useGetTokenUsdPrice';
 
 export type ExchangeRates = {
@@ -8,7 +8,6 @@ export type ExchangeRates = {
 };
 
 export const useTokenPrices = () => {
-    const { network } = useVeChainKitConfig();
     const config = useAppConfig();
 
     // Fetch base token prices

--- a/packages/vechain-kit/src/hooks/signing/useSignTypedData.ts
+++ b/packages/vechain-kit/src/hooks/signing/useSignTypedData.ts
@@ -1,5 +1,6 @@
 'use client';
 
+// TODO: investigate signTypedData support in VeWorld in-app browser
 import { useCallback, useState } from 'react';
 import { SignTypedDataParams } from '@privy-io/react-auth';
 import { usePrivyWalletProvider } from '@/providers';

--- a/packages/vechain-kit/src/languages/en.json
+++ b/packages/vechain-kit/src/languages/en.json
@@ -423,5 +423,7 @@
     "unavailable": "unavailable",
     "utilities": "Utilities",
     "vebetter": "VeBetter",
-    "your@email.com": "your@email.com"
+    "your@email.com": "your@email.com",
+    "Paste a token contract address to track its balance in your wallet.": "Paste a token contract address to track its balance in your wallet.",
+    "No custom tokens added yet.": "No custom tokens added yet."
 }

--- a/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
+++ b/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
@@ -1,4 +1,4 @@
-import { getConfig } from '@/config';
+import { AppConfig, getConfig } from '@/config';
 import { NETWORK_TYPE } from '@/config/network';
 import { CURRENCY, PrivyLoginMethod } from '@/types';
 import { isValidUrl } from '@/utils';
@@ -146,6 +146,23 @@ export type VechainKitProviderProps = {
     allowCustomTokens?: boolean;
     /** When true, community tokens (e.g. SASS) are included in token lists and balances. */
     allowCommunityTokens?: boolean;
+    /**
+     * Override default contract addresses for the selected network.
+     * Useful when deploying custom contract instances (e.g., on solo or testnet).
+     * Only the provided fields are overridden; the rest use the network defaults.
+     *
+     * @example
+     * ```tsx
+     * <VeChainKitProvider
+     *   network={{ type: 'solo' }}
+     *   contractAddresses={{
+     *     b3trContractAddress: '0x...',
+     *     vot3ContractAddress: '0x...',
+     *   }}
+     * >
+     * ```
+     */
+    contractAddresses?: Partial<AppConfig>;
     legalDocuments?: LegalDocumentOptions;
     hiddenQuickActions?: AccountQuickAction[];
     defaultCurrency?: CURRENCY;
@@ -166,6 +183,8 @@ export type VeChainKitConfig = {
     loginMethods?: VechainKitProviderProps['loginMethods'];
     darkMode: boolean;
     i18n?: VechainKitProviderProps['i18n'];
+    /** The full app config for the current network, with any contractAddresses overrides applied. */
+    appConfig: AppConfig;
     network: {
         type: NETWORK_TYPE;
         nodeUrl: string;
@@ -219,6 +238,21 @@ export const useVeChainKitConfig = () => {
         throw new Error('useVeChainKitConfig must be used within VeChainKit');
     }
     return context;
+};
+
+/**
+ * Hook to get the merged app config for the current network.
+ * Returns the base network config with any contractAddresses overrides applied.
+ *
+ * @example
+ * ```tsx
+ * const config = useAppConfig();
+ * const b3trAddress = config.b3trContractAddress;
+ * ```
+ */
+export const useAppConfig = (): AppConfig => {
+    const { appConfig } = useVeChainKitConfig();
+    return appConfig;
 };
 
 const validateConfig = (
@@ -372,6 +406,7 @@ export const VeChainKitProvider = (
         theme: customTheme,
         onLanguageChange,
         onCurrencyChange,
+        contractAddresses,
     } = validatedProps;
 
     // After validation, network and dappKit are guaranteed to be defined
@@ -386,6 +421,15 @@ export const VeChainKitProvider = (
         type: networkType,
         nodeUrl,
     };
+
+    // Merge base config with any contract address overrides
+    const appConfig = useMemo(
+        () => ({
+            ...getConfig(networkType),
+            ...contractAddresses,
+        }),
+        [networkType, contractAddresses],
+    );
 
     const dappKit = _dappKit ?? {
         allowedWallets: ['veworld'] as DAppKitWalletSource[],
@@ -645,6 +689,7 @@ export const VeChainKitProvider = (
                         loginMethods: validatedLoginMethods,
                         darkMode,
                         i18n: i18nConfig,
+                        appConfig,
                         currentLanguage,
                         network,
                         allowCustomTokens,


### PR DESCRIPTION
## Summary
- Add `contractAddresses` prop to `VeChainKitProvider` to override default contract addresses (e.g., B3TR, VOT3) for custom deployments on solo/testnet
- Add `useAppConfig()` hook and `appConfig` context field for accessing the merged config
- Move "Manage Custom Tokens" button inline with search bar as an icon button for easier reachability
- Restyle the Manage Custom Tokens screen with helper text, inline add button, empty state, and clearer token list layout
- Bump version to 2.7.0

## Test plan
- [ ] Verify `contractAddresses` prop overrides B3TR/VOT3 addresses on testnet/solo
- [ ] Verify `useAppConfig()` returns merged config with overrides
- [ ] Verify manage custom tokens icon button appears next to search bar in assets view
- [ ] Verify adding/removing custom tokens works in the restyled screen
- [ ] Verify empty state shows when no custom tokens exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to override network contract addresses through provider configuration
  * Redesigned custom token management interface with improved layout and inline controls
  * Added signing example to homepage

* **Improvements**
  * Enhanced configuration system for better contract address management

* **Chores**
  * Bumped package version to 2.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->