### PR TITLE
fix: drive kit color mode from darkMode prop, ignore localStorage

### DIFF
--- a/packages/vechain-kit/src/providers/VechainKitThemeProvider.tsx
+++ b/packages/vechain-kit/src/providers/VechainKitThemeProvider.tsx
@@ -1,9 +1,7 @@
 import {
     ChakraProvider,
     createStandaloneToast,
-    ColorModeScript,
     Box,
-    useColorMode,
 } from '@chakra-ui/react';
 import { CacheProvider, Global, css } from '@emotion/react';
 import createCache from '@emotion/cache';
@@ -11,12 +9,10 @@ import {
     createContext,
     ReactNode,
     useContext,
-    useEffect,
     useMemo,
     useRef,
 } from 'react';
 import { getVechainKitTheme } from '@/theme';
-import { safeQuerySelector } from '@/utils/ssrUtils';
 import type { VechainKitThemeConfig } from '../theme/tokens';
 import { VeChainKitContext } from './VeChainKitProvider';
 import { ThemeTokens } from '@/theme/tokens';
@@ -138,11 +134,13 @@ const EnsureChakraProvider = ({
     theme,
     bodyFont,
     headingFont,
+    colorModeManager,
 }: {
     children: ReactNode;
     theme: any;
     bodyFont: string;
     headingFont: string;
+    colorModeManager: any;
 }) => {
     const cache = useMemo(() => createVeChainKitCache(), []);
 
@@ -157,26 +155,12 @@ const EnsureChakraProvider = ({
                 // Undefined portal z-index allows host apps to control their own z-index hierarchy
                 // instead of Chakra forcing high values (1500+) that might conflict
                 portalZIndex={undefined}
+                colorModeManager={colorModeManager}
             >
                 {children}
             </ChakraProvider>
         </CacheProvider>
     );
-};
-
-const EnsureColorModeScript = ({ darkMode }: { darkMode: boolean }) => {
-    try {
-        // Check if ColorModeScript already exists by looking for its data attribute
-        const existingScript = safeQuerySelector('[data-chakra-color-mode]');
-        if (existingScript) {
-            return null; // Don't render another one if it exists
-        }
-    } catch (e) {
-        console.error(e);
-    }
-
-    // If no ColorModeScript exists, provide one
-    return <ColorModeScript initialColorMode={darkMode ? 'dark' : 'light'} />;
 };
 
 const VechainKitThemeContext = createContext<{
@@ -197,18 +181,6 @@ export const useVechainKitThemeConfig = () => {
         );
     }
     return context;
-};
-
-export const ColorModeSync = ({ darkMode = false }: { darkMode: boolean }) => {
-    const { setColorMode, colorMode: currentColorMode } = useColorMode();
-
-    useEffect(() => {
-        const colorMode = darkMode ? 'dark' : 'light';
-
-        if (currentColorMode !== colorMode) setColorMode(colorMode);
-    }, [darkMode]);
-
-    return <></>;
 };
 
 export const VechainKitThemeProvider = ({
@@ -244,17 +216,32 @@ export const VechainKitThemeProvider = ({
         [darkMode, effectiveTheme],
     );
 
+    // The `darkMode` prop is the single source of truth for the kit's color
+    // mode. We feed Chakra's ColorModeProvider a manager that always reports
+    // the current prop value and ignores writes, so it never reads or writes
+    // localStorage. Without this, Chakra's mount-time effect reads a stale
+    // `chakra-ui-color-mode` value and overrides the prop — visible as the
+    // kit being stuck in dark mode when the host is light.
+    const colorModeManager = useMemo(
+        () => ({
+            type: 'localStorage' as const,
+            ssr: false,
+            get: () => (darkMode ? 'dark' : 'light'),
+            set: () => {},
+        }),
+        [darkMode],
+    );
+
     return (
         <VechainKitThemeContext.Provider
             value={{ portalRootRef, tokens, themeConfig: effectiveTheme }}
         >
-            <EnsureColorModeScript darkMode={darkMode} />
             <EnsureChakraProvider
                 theme={theme}
                 bodyFont={tokens.fonts.body}
                 headingFont={tokens.fonts.heading}
+                colorModeManager={colorModeManager}
             >
-                <ColorModeSync darkMode={darkMode} />
                 <Box
                     id="vechain-kit-root"
                     ref={portalRootRef}


### PR DESCRIPTION
## Summary

- Chakra v2's `ColorModeProvider` inside the kit reads `localStorage["chakra-ui-color-mode"]` in a mount-time effect and overwrites its internal state with that stale value, ignoring the `darkMode` prop. The old `ColorModeSync` compared the *initial* `colorMode` against the target before Chakra's effect ran, so it never corrected the drift.
- React 19 / Next 16 strict mode makes the effect ordering deterministic, so light mode is now permanently broken in hosts that previously rendered the kit in dark mode (e.g. Next 16 + Chakra v3 + next-themes apps like b3tr). Before Next 16, a refresh sometimes recovered.
- Replace `ColorModeScript` + `ColorModeSync` with a custom `colorModeManager` passed to `ChakraProvider` that always reports the current `darkMode` prop value and no-ops writes. The manager's identity is keyed on `darkMode`, so a flip re-triggers Chakra's read effect and the internal color mode tracks the prop without ever touching `localStorage`.

Closes #608 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified theme color-mode handling to provide more reliable control and consistency across the application. Theme configuration is now unified and centrally managed.

* **Breaking Changes**
  * Removed an internal theming component that is no longer necessary with the refactored approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/vechain-kit/pull/613)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->