### PR TITLE
fix(connect-modal): VeWorld Universal Link fallback when extension missing — v2.8.2

### DIFF
--- a/examples/homepage/package.json
+++ b/examples/homepage/package.json
@@ -18,7 +18,7 @@
         "@vechain/vechain-kit": "workspace:*",
         "i18next": "^24.2.1",
         "i18next-browser-languagedetector": "^8.0.2",
-        "next": ">=15.2.3",
+        "next": "~16.2.3",
         "react": "^18",
         "react-dom": "^18",
         "react-i18next": "^15.4.0"

--- a/examples/next-chakra-v3/.gitignore
+++ b/examples/next-chakra-v3/.gitignore
@@ -1,0 +1,39 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# build output
+/.next/
+/out/
+/build
+/dist
+
+# testing
+/coverage
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env
+.env
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# turbo
+.turbo

--- a/examples/next-chakra-v3/README.md
+++ b/examples/next-chakra-v3/README.md
@@ -1,0 +1,34 @@
+# next-chakra-v3
+
+Minimal repro of b3tr's frontend stack for debugging vechain-kit theming and
+color-mode propagation **without publishing new kit versions**.
+
+What this mirrors from b3tr:
+
+- Next.js (App Router) + React 18 — the monorepo's root `resolutions`
+  field pins `next` to 15.5.9, so this example uses 15.5.9 instead of
+  b3tr's 16.2.x. The bug we're chasing is in the kit / Chakra-v3 host
+  interaction, not in Next itself, so this doesn't affect reproducibility.
+- Chakra UI v3 with `cssVarsPrefix: "vbd"` and semantic tokens that have
+  `_dark` variants
+- next-themes (`attribute="class"`) driving the color mode
+- A `useColorMode` wrapper that reads `resolvedTheme` from `useTheme()`
+- A `VechainKitProviderWrapper` that pipes `useToken('colors', [...])`
+  results — which Chakra v3 returns as CSS variable references like
+  `var(--vbd-colors-bg-primary)` — straight into the kit's `theme` prop and
+  passes `darkMode={colorMode === 'dark'}`
+
+The kit is workspace-linked (`workspace:*`), so any change in
+`packages/vechain-kit/src` flows through after a `yarn watch` rebuild.
+
+## Run
+
+```bash
+# from repo root
+yarn install:all   # only the first time, or after pulling dep changes
+yarn dev:next-chakra-v3
+```
+
+The example serves on http://localhost:3001. Click the sun/moon icon to
+toggle `next-themes`; open the connect modal to inspect kit theme
+propagation.

--- a/examples/next-chakra-v3/next.config.js
+++ b/examples/next-chakra-v3/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+    reactStrictMode: true,
+    experimental: {
+        optimizePackageImports: ['@chakra-ui/react', '@vechain/vechain-kit'],
+    },
+    eslint: { ignoreDuringBuilds: true },
+    typescript: { ignoreBuildErrors: true },
+};
+
+module.exports = nextConfig;

--- a/examples/next-chakra-v3/package.json
+++ b/examples/next-chakra-v3/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "next-chakra-v3",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "build": "next build",
+        "clean": "rm -rf .next dist .turbo",
+        "dev": "next dev --turbopack --port 3010",
+        "start": "next start"
+    },
+    "dependencies": {
+        "@chakra-ui/react": "^3.26.0",
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@tanstack/react-query": "^5.64.2",
+        "@vechain/vechain-kit": "workspace:*",
+        "framer-motion": "^11.0.0",
+        "next": "~16.2.3",
+        "next-themes": "^0.4.6",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-icons": "^5.4.0"
+    },
+    "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
+        "typescript": "5.3.3"
+    }
+}

--- a/examples/next-chakra-v3/src/app/layout.tsx
+++ b/examples/next-chakra-v3/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import { Providers } from './providers';
+
+export const metadata = {
+    title: 'VeChain Kit · Chakra v3 + next-themes repro',
+};
+
+export default function RootLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <html lang="en" suppressHydrationWarning>
+            <body>
+                <Providers>{children}</Providers>
+            </body>
+        </html>
+    );
+}

--- a/examples/next-chakra-v3/src/app/page.tsx
+++ b/examples/next-chakra-v3/src/app/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+import {
+    Box,
+    Button,
+    Code,
+    HStack,
+    Heading,
+    Stack,
+    Text,
+} from '@chakra-ui/react';
+import {
+    useAccountModal,
+    useConnectModal,
+    useWallet,
+} from '@vechain/vechain-kit';
+import { ColorModeButton, useColorMode } from '@/components/ui/color-mode';
+
+const short = (addr?: string) =>
+    addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : '';
+
+export default function Page() {
+    const { open: openConnect } = useConnectModal();
+    const { open: openAccount } = useAccountModal();
+    const { account, connection, disconnect } = useWallet();
+    const { colorMode } = useColorMode();
+
+    const isConnected = connection.isConnected;
+
+    return (
+        <Stack gap={6} p={8} maxW="720px" mx="auto">
+            <HStack justify="space-between">
+                <Heading size="lg">VeChain Kit · Chakra v3 repro</Heading>
+                <ColorModeButton />
+            </HStack>
+
+            <Text>
+                Host is on Chakra v3 + next-themes. Current resolved theme:{' '}
+                <Code>{colorMode ?? '—'}</Code>. Toggle the sun/moon icon and
+                re-open the modals to inspect theme propagation into the kit.
+            </Text>
+
+            <HStack gap={3}>
+                {!isConnected ? (
+                    <Button colorPalette="blue" onClick={() => openConnect()}>
+                        Open connect modal
+                    </Button>
+                ) : (
+                    <>
+                        <Button colorPalette="blue" onClick={() => openAccount()}>
+                            Open account modal
+                        </Button>
+                        <Button variant="outline" onClick={() => disconnect()}>
+                            Disconnect
+                        </Button>
+                    </>
+                )}
+            </HStack>
+
+            {isConnected && (
+                <Box
+                    p={3}
+                    rounded="md"
+                    borderWidth="1px"
+                    borderColor="border.secondary"
+                >
+                    <Text fontSize="sm">
+                        Connected as <Code>{short(account?.address)}</Code> via{' '}
+                        <Code>{connection.source.type}</Code>
+                    </Text>
+                </Box>
+            )}
+
+            <Box
+                p={4}
+                rounded="md"
+                borderWidth="1px"
+                borderColor="border.secondary"
+                bg="card.subtle"
+            >
+                <Text fontWeight="bold">Host-rendered card</Text>
+                <Text fontSize="sm">
+                    This box uses the same Chakra v3 semantic tokens
+                    (<Code>bg.primary</Code>, <Code>card.subtle</Code>,
+                    <Code> border.secondary</Code>) that are passed into the
+                    kit&apos;s theme prop. If everything is working, both kit
+                    modals should track theme toggles in real time without a
+                    refresh.
+                </Text>
+            </Box>
+        </Stack>
+    );
+}

--- a/examples/next-chakra-v3/src/app/providers.tsx
+++ b/examples/next-chakra-v3/src/app/providers.tsx
@@ -1,0 +1,18 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { Provider } from '@/components/ui/provider';
+
+const VechainKitProviderWrapper = dynamic(
+    async () =>
+        (await import('@/providers/VechainKitProviderWrapper'))
+            .VechainKitProviderWrapper,
+    { ssr: false },
+);
+
+export function Providers({ children }: { readonly children: React.ReactNode }) {
+    return (
+        <Provider>
+            <VechainKitProviderWrapper>{children}</VechainKitProviderWrapper>
+        </Provider>
+    );
+}

--- a/examples/next-chakra-v3/src/components/ui/color-mode.tsx
+++ b/examples/next-chakra-v3/src/components/ui/color-mode.tsx
@@ -1,0 +1,71 @@
+'use client';
+import {
+    ClientOnly,
+    IconButton,
+    IconButtonProps,
+    Skeleton,
+} from '@chakra-ui/react';
+import {
+    ThemeProvider,
+    ThemeProviderProps,
+    useTheme,
+} from 'next-themes';
+import * as React from 'react';
+import { FaMoon, FaSun } from 'react-icons/fa';
+
+// Mirrors b3tr's color-mode wrapper exactly. next-themes provides the
+// resolved theme; the kit receives `darkMode={colorMode === 'dark'}` from a
+// consumer of this hook.
+export interface ColorModeProviderProps extends ThemeProviderProps {}
+export function ColorModeProvider(props: ColorModeProviderProps) {
+    return (
+        <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
+    );
+}
+
+export type ColorMode = 'light' | 'dark';
+export interface UseColorModeReturn {
+    colorMode: ColorMode;
+    setColorMode: (colorMode: ColorMode) => void;
+    toggleColorMode: () => void;
+}
+
+export function useColorMode(): UseColorModeReturn {
+    const { resolvedTheme, setTheme, forcedTheme } = useTheme();
+    const colorMode = forcedTheme || resolvedTheme;
+    const toggleColorMode = () => {
+        setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+    };
+    return {
+        colorMode: colorMode as ColorMode,
+        setColorMode: setTheme as (m: ColorMode) => void,
+        toggleColorMode,
+    };
+}
+
+export function ColorModeIcon() {
+    const { colorMode } = useColorMode();
+    return colorMode === 'light' ? <FaMoon /> : <FaSun />;
+}
+
+interface ColorModeButtonProps extends Omit<IconButtonProps, 'aria-label'> {}
+
+export const ColorModeButton = React.forwardRef<
+    HTMLButtonElement,
+    ColorModeButtonProps
+>(function ColorModeButton(props, ref) {
+    const { toggleColorMode } = useColorMode();
+    return (
+        <ClientOnly fallback={<Skeleton boxSize="8" />}>
+            <IconButton
+                onClick={toggleColorMode}
+                variant="ghost"
+                aria-label="Toggle color mode"
+                ref={ref}
+                {...props}
+            >
+                <ColorModeIcon />
+            </IconButton>
+        </ClientOnly>
+    );
+});

--- a/examples/next-chakra-v3/src/components/ui/provider.tsx
+++ b/examples/next-chakra-v3/src/components/ui/provider.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { ChakraProvider } from '@chakra-ui/react';
+import theme from '@/theme/theme';
+import { ColorModeProvider, type ColorModeProviderProps } from './color-mode';
+
+export function Provider(props: ColorModeProviderProps) {
+    return (
+        <ChakraProvider value={theme}>
+            <ColorModeProvider {...props} />
+        </ChakraProvider>
+    );
+}

--- a/examples/next-chakra-v3/src/providers/VechainKitProviderWrapper.tsx
+++ b/examples/next-chakra-v3/src/providers/VechainKitProviderWrapper.tsx
@@ -1,0 +1,115 @@
+'use client';
+import { useChakraContext, useToken } from '@chakra-ui/react';
+import dynamic from 'next/dynamic';
+import { useColorMode } from '@/components/ui/color-mode';
+
+// Same dynamic-import-with-ssr-false pattern b3tr uses.
+const VeChainKitProvider = dynamic(
+    () =>
+        import('@vechain/vechain-kit').then((mod) => mod.VeChainKitProvider),
+    { ssr: false },
+);
+
+interface Props {
+    readonly children: React.ReactNode;
+}
+
+export function VechainKitProviderWrapper({ children }: Props) {
+    const { colorMode } = useColorMode();
+    const isDarkMode = colorMode === 'dark';
+
+    // KEY REPRODUCTION DETAIL: `useToken` in Chakra v3 returns the CSS
+    // variable reference (e.g. `var(--vbd-colors-bg-primary)`), NOT the
+    // resolved color. Its value flips at paint time based on
+    // `html.class="dark"`. The kit must keep these references intact so they
+    // stay reactive — any path inside the kit that snapshots the resolved
+    // color (e.g. by appending a temp element to the DOM and reading
+    // computed style) freezes the value at render time and breaks the
+    // theme toggle for everything derived from it.
+    // Chakra v3 quirk: `useToken('colors', 'bg.primary')` returns the
+    // resolved literal value (e.g. `#1B1D1F`) at render time, NOT a CSS
+    // variable reference. That snapshot is darkMode-frozen and breaks
+    // theme toggling once it's piped into the kit. Use `sys.token.var(...)`
+    // (or build `var(--vbd-colors-bg-primary)` by hand) so the value stays
+    // reactive to host theme changes.
+    const sys = useChakraContext();
+    const tokVar = (path: string) =>
+        sys.token.var(`colors.${path}`) as string;
+    const bgPrimary = tokVar('bg.primary');
+    const primaryDefault = tokVar('actions.primary.default');
+    const primaryText = tokVar('actions.primary.text');
+    const primaryHover = tokVar('actions.primary.hover');
+    const secondaryDefault = tokVar('card.subtle');
+    const secondaryHover = tokVar('card.hover');
+    const borderSecondary = tokVar('border.secondary');
+    // (still importing useToken for shape parity with b3tr's wrapper, even
+    // though we don't call it — left as a reminder that this is the broken
+    // path we're avoiding)
+    void useToken;
+
+    return (
+        <VeChainKitProvider
+            theme={{
+                modal: {
+                    backgroundColor: bgPrimary,
+                    border: `1px solid ${borderSecondary}`,
+                    useBottomSheetOnMobile: true,
+                },
+                buttons: {
+                    primaryButton: {
+                        bg: primaryDefault,
+                        color: primaryText,
+                        hoverBg: primaryHover,
+                        rounded: 'full',
+                    },
+                    secondaryButton: {
+                        border: `1px solid ${borderSecondary}`,
+                        bg: secondaryDefault,
+                        hoverBg: secondaryHover,
+                    },
+                },
+            }}
+            privy={{
+                appId:
+                    process.env.NEXT_PUBLIC_PRIVY_APP_ID ||
+                    'cm4wxxujb022fyujl7g0thb21',
+                clientId:
+                    process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID ||
+                    'client-WY5eXujRFovfkYSxufm6NM9CjAzeTqFw5tSd4hJPyA9nk',
+                loginMethods: ['google', 'apple', 'twitter'],
+                appearance: {
+                    loginMessage: 'Select a login method',
+                    logo: 'https://vechain-brand-assets.s3.eu-north-1.amazonaws.com/VeChain_Logomark_Light.png',
+                },
+                embeddedWallets: { createOnLogin: 'all-users' },
+            }}
+            dappKit={{
+                allowedWallets: ['veworld', 'wallet-connect'],
+                walletConnectOptions: {
+                    projectId:
+                        process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ||
+                        '06c045cd12ae0906fe5ad7d737fcdc04',
+                    metadata: {
+                        name: 'next-chakra-v3 repro',
+                        description: 'Reproduces b3tr theme integration',
+                        url:
+                            typeof window !== 'undefined'
+                                ? window.location.origin
+                                : '',
+                        icons: [],
+                    },
+                },
+            }}
+            loginMethods={[
+                { method: 'veworld', gridColumn: 4 },
+                { method: 'vechain', gridColumn: 4 },
+                { method: 'dappkit', gridColumn: 4 },
+                { method: 'ecosystem', gridColumn: 4 },
+            ]}
+            darkMode={isDarkMode}
+            network={{ type: 'main' }}
+        >
+            {children}
+        </VeChainKitProvider>
+    );
+}

--- a/examples/next-chakra-v3/src/theme/theme.ts
+++ b/examples/next-chakra-v3/src/theme/theme.ts
@@ -1,0 +1,95 @@
+import { createSystem, defaultConfig, defineConfig } from '@chakra-ui/react';
+
+// Mirror b3tr's theme shape: a `cssVarsPrefix` and semantic tokens with
+// `_dark` variants. The kit receives `useToken(...)` results from these
+// tokens, which resolve to `var(--vbd-colors-*)` CSS variable references
+// whose underlying value flips based on `html.class="dark"`.
+const config = defineConfig({
+    preflight: true,
+    cssVarsPrefix: 'vbd',
+    theme: {
+        tokens: {
+            colors: {
+                gray: {
+                    50: { value: '#F9F9FA' },
+                    100: { value: '#F1F2F3' },
+                    200: { value: '#E7E9EB' },
+                    700: { value: '#363A3F' },
+                    800: { value: '#272A2E' },
+                    900: { value: '#1B1D1F' },
+                },
+                blue: {
+                    400: { value: '#4D88FF' },
+                    600: { value: '#004CFC' },
+                    700: { value: '#003ECC' },
+                },
+            },
+        },
+        semanticTokens: {
+            colors: {
+                bg: {
+                    primary: {
+                        value: { base: 'white', _dark: '{colors.gray.900}' },
+                    },
+                    secondary: {
+                        value: { base: '{colors.gray.50}', _dark: '#0F0F0F' },
+                    },
+                },
+                actions: {
+                    primary: {
+                        default: {
+                            value: {
+                                base: '{colors.blue.600}',
+                                _dark: '{colors.blue.400}',
+                            },
+                        },
+                        hover: {
+                            value: {
+                                base: '{colors.blue.700}',
+                                _dark: '{colors.blue.400}',
+                            },
+                        },
+                        text: { value: { base: 'white', _dark: 'white' } },
+                    },
+                },
+                card: {
+                    subtle: {
+                        value: {
+                            base: '{colors.gray.50}',
+                            _dark: '{colors.gray.700}',
+                        },
+                        hover: {
+                            value: {
+                                base: '{colors.gray.100}',
+                                _dark: '{colors.gray.800}',
+                            },
+                        },
+                    },
+                },
+                border: {
+                    secondary: {
+                        value: {
+                            base: '{colors.gray.100}',
+                            _dark: '{colors.gray.800}',
+                        },
+                    },
+                },
+                text: {
+                    primary: {
+                        value: { base: '{colors.gray.800}', _dark: 'white' },
+                    },
+                },
+            },
+        },
+        globalCss: {
+            'html,body': {
+                bg: 'bg.secondary',
+                color: 'text.primary',
+                transition: 'background-color 0.2s, color 0.2s',
+            },
+        },
+    },
+});
+
+const theme = createSystem(defaultConfig, config);
+export default theme;

--- a/examples/next-chakra-v3/tsconfig.json
+++ b/examples/next-chakra-v3/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "preserve",
+        "incremental": true,
+        "plugins": [{ "name": "next" }],
+        "paths": {
+            "@/*": ["./src/*"]
+        }
+    },
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "exclude": ["node_modules"]
+}

--- a/examples/next-template/package.json
+++ b/examples/next-template/package.json
@@ -16,7 +16,7 @@
         "@vechain/vechain-kit": "workspace:*",
         "i18next": "^24.2.1",
         "i18next-browser-languagedetector": "^8.0.2",
-        "next": ">=15.2.3",
+        "next": "~16.2.3",
         "react": "^18",
         "react-dom": "^18",
         "react-i18next": "^15.4.0"

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -18,7 +18,7 @@
         "@vechain/vechain-kit": "workspace:*",
         "i18next": "^24.2.1",
         "i18next-browser-languagedetector": "^8.0.2",
-        "next": ">=15.2.3",
+        "next": "~16.2.3",
         "react": "^18",
         "react-dom": "^18",
         "react-i18next": "^15.4.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "dev:homepage": "yarn workspace @vechain/vechain-kit watch & yarn workspace vechain-kit-homepage dev",
         "dev:homepage:build": "yarn workspace @vechain/vechain-kit build & yarn workspace vechain-kit-homepage build",
         "dev:next-template": "yarn workspace @vechain/vechain-kit watch & yarn workspace next-template dev",
-        "dev:next-template:build": "yarn workspace @vechain/vechain-kit build & yarn workspace next-template build"
+        "dev:next-template:build": "yarn workspace @vechain/vechain-kit build & yarn workspace next-template build",
+        "dev:next-chakra-v3": "yarn workspace @vechain/vechain-kit watch & yarn workspace next-chakra-v3 dev"
     },
     "husky": {
         "hooks": {

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {

--- a/packages/vechain-kit/src/hooks/login/useConnectWithDappKitSource.ts
+++ b/packages/vechain-kit/src/hooks/login/useConnectWithDappKitSource.ts
@@ -16,6 +16,15 @@ const sourceDisplayName: Record<WalletSource, string> = {
     'wallet-connect': 'WalletConnect',
 };
 
+/**
+ * VeWorld Universal Link entry point. Hitting this URL on a phone with
+ * VeWorld installed opens the dApp inside VeWorld's in-app browser; on
+ * desktop or on a phone without the app it lands on the install page.
+ * Mirrors the fallback used by dapp-kit-ui's ConnectModal when
+ * `window.vechain` is missing.
+ */
+const VEWORLD_UNIVERSAL_LINK = 'https://www.veworld.com/discover/browser/ul/';
+
 const extractErrorMessage = (err: unknown): string => {
     if (typeof err === 'string') return err;
     if (err instanceof Error) return err.message;
@@ -55,6 +64,22 @@ export const useConnectWithDappKitSource = (
         const tryAgain = () => {
             void connect();
         };
+
+        // When VeWorld is selected but the extension isn't injected, fall
+        // back to the Universal Link — opens the dApp inside VeWorld mobile
+        // on phones, the install page on desktop. Same behavior as
+        // dapp-kit-ui's ConnectModal.
+        if (
+            source === 'veworld' &&
+            typeof window !== 'undefined' &&
+            !window.vechain
+        ) {
+            window.open(
+                `${VEWORLD_UNIVERSAL_LINK}${encodeURIComponent(window.location.href)}`,
+                '_self',
+            );
+            return;
+        }
 
         setCurrentContent({
             type: 'loading',

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,84 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ark-ui/react@npm:5.36.2":
+  version: 5.36.2
+  resolution: "@ark-ui/react@npm:5.36.2"
+  dependencies:
+    "@internationalized/date": "npm:3.12.0"
+    "@zag-js/accordion": "npm:1.40.0"
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/angle-slider": "npm:1.40.0"
+    "@zag-js/async-list": "npm:1.40.0"
+    "@zag-js/auto-resize": "npm:1.40.0"
+    "@zag-js/avatar": "npm:1.40.0"
+    "@zag-js/carousel": "npm:1.40.0"
+    "@zag-js/cascade-select": "npm:1.40.0"
+    "@zag-js/checkbox": "npm:1.40.0"
+    "@zag-js/clipboard": "npm:1.40.0"
+    "@zag-js/collapsible": "npm:1.40.0"
+    "@zag-js/collection": "npm:1.40.0"
+    "@zag-js/color-picker": "npm:1.40.0"
+    "@zag-js/color-utils": "npm:1.40.0"
+    "@zag-js/combobox": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/date-input": "npm:1.40.0"
+    "@zag-js/date-picker": "npm:1.40.0"
+    "@zag-js/date-utils": "npm:1.40.0"
+    "@zag-js/dialog": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/drawer": "npm:1.40.0"
+    "@zag-js/editable": "npm:1.40.0"
+    "@zag-js/file-upload": "npm:1.40.0"
+    "@zag-js/file-utils": "npm:1.40.0"
+    "@zag-js/floating-panel": "npm:1.40.0"
+    "@zag-js/focus-trap": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/highlight-word": "npm:1.40.0"
+    "@zag-js/hover-card": "npm:1.40.0"
+    "@zag-js/i18n-utils": "npm:1.40.0"
+    "@zag-js/image-cropper": "npm:1.40.0"
+    "@zag-js/json-tree-utils": "npm:1.40.0"
+    "@zag-js/listbox": "npm:1.40.0"
+    "@zag-js/marquee": "npm:1.40.0"
+    "@zag-js/menu": "npm:1.40.0"
+    "@zag-js/navigation-menu": "npm:1.40.0"
+    "@zag-js/number-input": "npm:1.40.0"
+    "@zag-js/pagination": "npm:1.40.0"
+    "@zag-js/password-input": "npm:1.40.0"
+    "@zag-js/pin-input": "npm:1.40.0"
+    "@zag-js/popover": "npm:1.40.0"
+    "@zag-js/presence": "npm:1.40.0"
+    "@zag-js/progress": "npm:1.40.0"
+    "@zag-js/qr-code": "npm:1.40.0"
+    "@zag-js/radio-group": "npm:1.40.0"
+    "@zag-js/rating-group": "npm:1.40.0"
+    "@zag-js/react": "npm:1.40.0"
+    "@zag-js/scroll-area": "npm:1.40.0"
+    "@zag-js/select": "npm:1.40.0"
+    "@zag-js/signature-pad": "npm:1.40.0"
+    "@zag-js/slider": "npm:1.40.0"
+    "@zag-js/splitter": "npm:1.40.0"
+    "@zag-js/steps": "npm:1.40.0"
+    "@zag-js/switch": "npm:1.40.0"
+    "@zag-js/tabs": "npm:1.40.0"
+    "@zag-js/tags-input": "npm:1.40.0"
+    "@zag-js/timer": "npm:1.40.0"
+    "@zag-js/toast": "npm:1.40.0"
+    "@zag-js/toggle": "npm:1.40.0"
+    "@zag-js/toggle-group": "npm:1.40.0"
+    "@zag-js/tooltip": "npm:1.40.0"
+    "@zag-js/tour": "npm:1.40.0"
+    "@zag-js/tree-view": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/e7fc19cfc86be698f06116e642212eb08f552a3fe73db61799996fb8baef418d5ecd1cf89b582b93347857468d47f70cc7361b2cdf27003e2972198bc5b8b893
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -1405,6 +1483,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chakra-ui/react@npm:^3.26.0":
+  version: 3.35.0
+  resolution: "@chakra-ui/react@npm:3.35.0"
+  dependencies:
+    "@ark-ui/react": "npm:5.36.2"
+    "@emotion/is-prop-valid": "npm:^1.4.0"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.2.0"
+    "@emotion/utils": "npm:^1.4.2"
+    "@pandacss/is-valid-prop": "npm:^1.4.2"
+    csstype: "npm:^3.2.3"
+  peerDependencies:
+    "@emotion/react": ">=11"
+    react: ">=18"
+    react-dom: ">=18"
+  checksum: 10c0/30d56362efc638fb35aeb1b0b3bc92c6ea0e85a5dd6ef48cbf9a94b7982654d1dbe3e2c01ed9ebcf661fed458c2b4085ff7331e8e891eec543067f0ae01d5780
+  languageName: node
+  linkType: hard
+
 "@chakra-ui/select@npm:2.1.2":
   version: 2.1.2
   resolution: "@chakra-ui/select@npm:2.1.2"
@@ -2356,7 +2453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/is-prop-valid@npm:^1.3.0":
+"@emotion/is-prop-valid@npm:^1.3.0, @emotion/is-prop-valid@npm:^1.4.0":
   version: 1.4.0
   resolution: "@emotion/is-prop-valid@npm:1.4.0"
   dependencies:
@@ -2379,7 +2476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:^11.13.5":
+"@emotion/react@npm:^11.13.5, @emotion/react@npm:^11.14.0":
   version: 11.14.0
   resolution: "@emotion/react@npm:11.14.0"
   dependencies:
@@ -2420,7 +2517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/styled@npm:^11.13.5, @emotion/styled@npm:^11.14.1":
+"@emotion/styled@npm:^11.13.5, @emotion/styled@npm:^11.14.0, @emotion/styled@npm:^11.14.1":
   version: 11.14.1
   resolution: "@emotion/styled@npm:11.14.1"
   dependencies:
@@ -3177,6 +3274,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
+  languageName: node
+  linkType: hard
+
 "@floating-ui/dom@npm:^1.7.4":
   version: 1.7.4
   resolution: "@floating-ui/dom@npm:1.7.4"
@@ -3184,6 +3290,16 @@ __metadata:
     "@floating-ui/core": "npm:^1.7.3"
     "@floating-ui/utils": "npm:^0.2.10"
   checksum: 10c0/da6166c25f9b0729caa9f498685a73a0e28251613b35d27db8de8014bc9d045158a23c092b405321a3d67c2064909b6e2a7e6c1c9cc0f62967dca5779f5aef30
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.5"
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/5c098e0d7b58c9bc769f276cca1766994c2c9c70c92d091a61bba8b3e9be53c011e0a79a8457fc2fb2f3d91697a26eb52e0a4962ef936dc963b45f58613c212f
   languageName: node
   linkType: hard
 
@@ -3217,6 +3333,13 @@ __metadata:
   version: 0.2.10
   resolution: "@floating-ui/utils@npm:0.2.10"
   checksum: 10c0/e9bc2a1730ede1ee25843937e911ab6e846a733a4488623cd353f94721b05ec2c9ec6437613a2ac9379a94c2fd40c797a2ba6fa1df2716f5ce4aa6ddb1cf9ea4
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: 10c0/f4bcea1559bdbb721ecc8e8ead423ac58d6a5b6e70b602cf0810ba6ad4ed1c77211b207faa88b278a9042f0c743133de08a203ed6741c1b6443423332884d5b3
   languageName: node
   linkType: hard
 
@@ -3533,6 +3656,24 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/414a3a2a9733459c57452d84ef19ff002222303d19041580685681153132d2a30af8f90f269b3967c30c670fa689dbb7d4fc25a86dc66f029eebe90dc7467b0a
+  languageName: node
+  linkType: hard
+
+"@internationalized/date@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@internationalized/date@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/6a26495d32f010b227a1f506da02cdf8438506014b41cfb81576c707a3dfe3d0fd207f80bcf28acd9eef8248a2c2da115cf9016515d513653ea1b22a796d0246
+  languageName: node
+  linkType: hard
+
+"@internationalized/number@npm:3.6.5":
+  version: 3.6.5
+  resolution: "@internationalized/number@npm:3.6.5"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/f87d710863a8dbf057aac311193c82f3c42e862abdd99e5b71034f1022926036552620eab5dd00c23e975f28b9e41e830cb342ba0264436749d9cdc5ae031d44
   languageName: node
   linkType: hard
 
@@ -4617,6 +4758,13 @@ __metadata:
   version: 0.97.0
   resolution: "@oxc-project/types@npm:0.97.0"
   checksum: 10c0/0e0c2e02eaccc685ed59692b7bf53554dc8b6d084c5cdcc12b6f7a46dafe197e189cd6ef05439ec27fa3a93d5437807419b97caf3fa0af55c9ab60efaa89a32c
+  languageName: node
+  linkType: hard
+
+"@pandacss/is-valid-prop@npm:^1.4.2":
+  version: 1.11.1
+  resolution: "@pandacss/is-valid-prop@npm:1.11.1"
+  checksum: 10c0/c5db1b88f7a6af6e222ad02999f1505582033e6e537e630b79d437b437d7e080c3483d0303cba0fbd397639615e7a9b95232611f3e79f895ca510d2e2f954c74
   languageName: node
   linkType: hard
 
@@ -8557,6 +8705,288 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zag-js/accordion@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/accordion@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/13e55b22ce41a32e5a06bde29dbfd9fd67d741e4da36aa5c8b334a5aab87ba80df57a3897d5f6609334ae83e21e025701a2e2993de2fbcfd2cae854f09e618fa
+  languageName: node
+  linkType: hard
+
+"@zag-js/anatomy@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/anatomy@npm:1.40.0"
+  checksum: 10c0/fdedc6b751757495cfe03f9f1831f463d0481ba0411ccc868dadffa4813cec87d236b755b56e4f204e3b9a062962e737289b5a68e3cde4673397e2bbf4a02513
+  languageName: node
+  linkType: hard
+
+"@zag-js/angle-slider@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/angle-slider@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/rect-utils": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/3d16bc1c8285e0e33795a5cc6aa085b2d0538f7f0cd5a93a0ca555c10e2b8b6743b6e1257d73e42b9545df6bbb48ebb826cfe37fba6edece702310d85616bebb
+  languageName: node
+  linkType: hard
+
+"@zag-js/aria-hidden@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/aria-hidden@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/999c0c5a0e823fa50ceee0b7d84e836173496f359a7988039baa8619d5038b08e1833638c9557a631b91327279a508fe5b6a1c0a866fbf1d0fc6854353aa5c59
+  languageName: node
+  linkType: hard
+
+"@zag-js/async-list@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/async-list@npm:1.40.0"
+  dependencies:
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/b092ac40ba16b3ddeb50356659c67638cdbfee280be856cba23a518c5e22152cfa5f12111f1621fc3df040838af5621cf4ec209c9a053002324eaff30a7dcd79
+  languageName: node
+  linkType: hard
+
+"@zag-js/auto-resize@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/auto-resize@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/6a250498a3ffad097082fc07ab40365a090d797de00fb8d4e5bc43d73e4c3640cfb412b2ba6d8bfb69124045990f4a677bba46e5fd16082a3d4f26907a715ef7
+  languageName: node
+  linkType: hard
+
+"@zag-js/avatar@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/avatar@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/1446ed80ba6fcbeda049a5020f0e4c438cd3817b31192793f3e70fa1ea58cebc81cc89490ac0b5982099de2b4da322ee9b6ddad48cc47b3b7380355d82d03032
+  languageName: node
+  linkType: hard
+
+"@zag-js/carousel@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/carousel@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/scroll-snap": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/861ba27fa42d4e76b581919172298eb4a562200debafce3b3aa5532a595a00a44588a44d0a359727a34719bad1f3a79da7c2306ae784d02b7183556355296a05
+  languageName: node
+  linkType: hard
+
+"@zag-js/cascade-select@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/cascade-select@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/collection": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/rect-utils": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/808688bbf7f3273b349f8f1d9dca11c2aec3715f31fecdd7e30c7842b1def33045252c842cbc867395640f5827ebe04c39aa819cdd14df17f636cf077e89bc9e
+  languageName: node
+  linkType: hard
+
+"@zag-js/checkbox@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/checkbox@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/dc3275bade349f38b1d6ff3768d3d8a969bbf2c7a0fe7f362f84bf2e42fbe4386319844a6867370e7df1c22b3037227757f143f6c1560b7fff1afffca575a9d5
+  languageName: node
+  linkType: hard
+
+"@zag-js/clipboard@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/clipboard@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/c11cd11a87508cd79440c61461f9952a6794e07be27c2720290441e8c88941873d9474b1549c77db7632f2ea7894602affd1c615e1f1ef664ee181b6d3a67584
+  languageName: node
+  linkType: hard
+
+"@zag-js/collapsible@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/collapsible@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/dec3f016a84708511649c4471a50a499813cfdd039accfeca4ec5e4b22d68c81a0a0360bf9689528b90ceefb4718bdc86cfca2e23bfefb7c1857a18f5ad4a9eb
+  languageName: node
+  linkType: hard
+
+"@zag-js/collection@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/collection@npm:1.40.0"
+  dependencies:
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/98e899e2b5c35d3f3aafb4f817d366311eaaebf5e9789b014c5f54e6cac176802b2632892db4905209e85a47ed0a54dc7db260c2500c52c68f8c532e8cf441e2
+  languageName: node
+  linkType: hard
+
+"@zag-js/color-picker@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/color-picker@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/color-utils": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/f6db66fe540ae74d47fb079f1a189ec3a3fe432a25f8a5b54d84c69c802b23a8cac9e5b6a785d649c8b6a18837d733eae53c2515c654a9ceeee0a695562dd074
+  languageName: node
+  linkType: hard
+
+"@zag-js/color-utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/color-utils@npm:1.40.0"
+  dependencies:
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/c51b9003f96a3cbf41708047544120492b93ef9909fac3a42121af5cd439d43ede6864836a218383d7e125c36e3ec5875e32b6f9358b70b4f1b668f2c4490f3a
+  languageName: node
+  linkType: hard
+
+"@zag-js/combobox@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/combobox@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/collection": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/live-region": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/025b7b1cbc889ffc752f00558b5e827e4c328e9d49f92675b21fe16b88096dd1097097068445c698a202f89691834813cbe895c7e41f42d06372aef5f19b71ed
+  languageName: node
+  linkType: hard
+
+"@zag-js/core@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/core@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/82b276256f9c95b52f9fc45cf42ba8fcac88c3619849f2e62ce05ce18c372a33474314f1516e8f71f240e2a037c3c79b40a556a414ae23c2ed5ca9702bb9bd5b
+  languageName: node
+  linkType: hard
+
+"@zag-js/date-input@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/date-input@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/date-utils": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/live-region": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  peerDependencies:
+    "@internationalized/date": ">=3.0.0"
+  checksum: 10c0/e856d2c906b1a6c3ef43f62086c51f12e65dd5d20af53e8817821159c868c8391a0ae7f00da627c05f3c0ef9566680fc40260f52d24bb63252640c27afd21a48
+  languageName: node
+  linkType: hard
+
+"@zag-js/date-picker@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/date-picker@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/date-utils": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/live-region": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  peerDependencies:
+    "@internationalized/date": ">=3.0.0"
+  checksum: 10c0/6e9c1f103459e0d6b900e4b6965376dfce22bdcaa7c126e7e1a8dd9befcf94ec64baf50e85da112f92febeee5f52a037d395ae7d71482d43742bb22f8f0e58e5
+  languageName: node
+  linkType: hard
+
+"@zag-js/date-utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/date-utils@npm:1.40.0"
+  peerDependencies:
+    "@internationalized/date": ">=3.0.0"
+  checksum: 10c0/cf0fb585ddb723d0642bd640f1abe783446fea57abf91d466150c4728f56e0b950e78f6293900c6f79e286b4b567e86901216a1543b74bc70718f56c4f629105
+  languageName: node
+  linkType: hard
+
+"@zag-js/dialog@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/dialog@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/aria-hidden": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-trap": "npm:1.40.0"
+    "@zag-js/remove-scroll": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/e6b9731feac4a0761176a3296d1d0609c04af607b53cfd05e396a770dc9383a573b7e11021a5a6d30dec17589b2322add07ab1d9b6e57217c5c5e830e5114be8
+  languageName: node
+  linkType: hard
+
+"@zag-js/dismissable@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/dismissable@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/interact-outside": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/58932f22f768c796e5b3cc0e5f41c2b44d6c86c1b0f391f05e31f319ffd56a761b936b59b8310bfd82bb0431ee5ed2c2defe91ab27f6f6dda44d5ff92b4f6b5c
+  languageName: node
+  linkType: hard
+
 "@zag-js/dom-query@npm:0.16.0":
   version: 0.16.0
   resolution: "@zag-js/dom-query@npm:0.16.0"
@@ -8568,6 +8998,46 @@ __metadata:
   version: 0.31.1
   resolution: "@zag-js/dom-query@npm:0.31.1"
   checksum: 10c0/a7346f832ec1a005a5c516ef822f32b6a06ebdf95b5aed37630b268767c4f6f2bd59d1cbb8bf80dca51daddc5b13f2c0131e3b37a981f86f1cd13f30c6409f60
+  languageName: node
+  linkType: hard
+
+"@zag-js/dom-query@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/dom-query@npm:1.40.0"
+  dependencies:
+    "@zag-js/types": "npm:1.40.0"
+  checksum: 10c0/5e7d14374565afdc4a25c318b7b939b84d803a01016bc293256e19ccf5654bd078774d13834eed85e1b43fa26ba27fdba9567b1ec62f83ec8c9c90337a51c468
+  languageName: node
+  linkType: hard
+
+"@zag-js/drawer@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/drawer@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/aria-hidden": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-trap": "npm:1.40.0"
+    "@zag-js/remove-scroll": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/593a362a81566d46272f3f18d9be5061c6d2441aa6ac719d8a749b9cb0cc43228b774ceb83a0b24901846ce756f66497a2dc9f29e74b387a5329ab360c661601
+  languageName: node
+  linkType: hard
+
+"@zag-js/editable@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/editable@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/interact-outside": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/58dfee0883534d4867cae094793143a9cd5ac6769a7c4cd7134457ea980cd8d14a88fcda2f26fedcaa531013211041904deffde511efdf33d22276ee25dac9b0
   languageName: node
   linkType: hard
 
@@ -8585,6 +9055,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zag-js/file-upload@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/file-upload@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/file-utils": "npm:1.40.0"
+    "@zag-js/i18n-utils": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/2ec5b9591e986e024b0456142a2c31f711fc0753524c1388ab62147e704707c37acd7393c6652cb392881297621e1f72d8f5f834c81e1eb960d5c83ee3dfe6d7
+  languageName: node
+  linkType: hard
+
+"@zag-js/file-utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/file-utils@npm:1.40.0"
+  dependencies:
+    "@zag-js/i18n-utils": "npm:1.40.0"
+  checksum: 10c0/e0663cb196bca13a4852b3512326e845f30f667efd1286f566ecc2ebf443b1313489512c826859d3f165f1335932ca936f1f335e59de12571f01a2b6e5212961
+  languageName: node
+  linkType: hard
+
+"@zag-js/floating-panel@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/floating-panel@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/rect-utils": "npm:1.40.0"
+    "@zag-js/store": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/e0f921dde0eece4c714fd75e441967749fb992c65a737b52f508bc1943046c5ab9b42b4f1e027c113dabbae4a2bd9a285daa0e70ead443f587ba17da0c9ce0db
+  languageName: node
+  linkType: hard
+
+"@zag-js/focus-trap@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/focus-trap@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/92cd050736ddc27a6a0b9e7b359b7dd9d18c05df9cd4350e0b11b51957c93341c637294b27570937edad6b0d27912dc41b235ad51b5232ddb3a6a4aea2477c3f
+  languageName: node
+  linkType: hard
+
 "@zag-js/focus-visible@npm:0.16.0":
   version: 0.16.0
   resolution: "@zag-js/focus-visible@npm:0.16.0"
@@ -8594,12 +9113,586 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zag-js/focus-visible@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/focus-visible@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/5bd5a4bb51a89673a0855a6013f0808e88c658baa587cc05a4623dd873da3dc66941b657830fbd156ec5a4e3bf3b240ae4a09484fa912f2d90ee704fa590d878
+  languageName: node
+  linkType: hard
+
 "@zag-js/focus-visible@npm:^0.31.1":
   version: 0.31.1
   resolution: "@zag-js/focus-visible@npm:0.31.1"
   dependencies:
     "@zag-js/dom-query": "npm:0.31.1"
   checksum: 10c0/7c6e0db4cf8ca4bba1814bf56ca6367fda10f6223078181db6bf8629bd3059485df0ad7a53665e2fb77d4dfa99ae6d1b5dc987bd3f88b5fca5134c6fa874d37a
+  languageName: node
+  linkType: hard
+
+"@zag-js/highlight-word@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/highlight-word@npm:1.40.0"
+  checksum: 10c0/7f4a00bd0c42a3245b28178e6216d19b691f17bb974b365bc3551b5eebb482f1844ddc0f646ed4416d14bbccaa7aec8b6e62b930f5d07dac289752f0f0f1073d
+  languageName: node
+  linkType: hard
+
+"@zag-js/hover-card@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/hover-card@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/03f6dc63c3295f42ca3f9a8c2cd88d929a84e2ac983c003ac2e4de84ff012df193a18e584a479f81daa46b0ad553905c9046de4a9267eec23d6abe5ed2989b68
+  languageName: node
+  linkType: hard
+
+"@zag-js/i18n-utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/i18n-utils@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/3c10a7a35902e4635c088fbccbba106444ef9c1e2d3c7b6af3d70e3e357337b1c6066d3f997e741882d19fd0d2b3a638f6ec5ab9a102278d7321ffa872de1bf5
+  languageName: node
+  linkType: hard
+
+"@zag-js/image-cropper@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/image-cropper@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/7db96c919ccf8ffe05ac6979e224cd9680ac999e4614307307a04ca8f965a2c6e6e240c8d4228c89e47fac7f6bb78c42d59a94a1ac22f909b2fafcb1eae8b497
+  languageName: node
+  linkType: hard
+
+"@zag-js/interact-outside@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/interact-outside@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/c289ab53c414768d5a69729c01ec4d0a195cfafd88249d68fc380338bf4eb970db27b0b3bbccaa029d66753152a4964ce568f1e65645511ab067deb2589cdc67
+  languageName: node
+  linkType: hard
+
+"@zag-js/json-tree-utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/json-tree-utils@npm:1.40.0"
+  checksum: 10c0/9c7072ca4f7c18a252f9dcd621d2592443a87c75d661ed8eea023a717d5d6f1b7ee37e8a1c648b2e94673a96e77905b58794d93a065077ae3cd18a6d007c8216
+  languageName: node
+  linkType: hard
+
+"@zag-js/listbox@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/listbox@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/collection": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/226b3a89d56843b921a350d8be2daf644293faa6c899a9b3ec16025e0173166e3a974845cf2eb9c3f9a77b0dc2a0ff2bacb29f2a0b50b668b3e1214aeb94cc42
+  languageName: node
+  linkType: hard
+
+"@zag-js/live-region@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/live-region@npm:1.40.0"
+  checksum: 10c0/a7b5b650410e82a02d2343cbcae96bf54a1a6ec524d9842bdddad8b36681d6465dea871b1af2edbbfa6d345ebe2abf157bb91b233a7beda1a24952d7b57b8d90
+  languageName: node
+  linkType: hard
+
+"@zag-js/marquee@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/marquee@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/eb674203b09d8b4d4341c1bf391950aac9aef77cd403451ce264715338e19a759cd0edb89c66d665dc422f9d0d52a9bf31d9615473ecd8fd667ebe707a1bf303
+  languageName: node
+  linkType: hard
+
+"@zag-js/menu@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/menu@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/rect-utils": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/424abe7d780f682c6c65b3de4b0e715dad4a3d80c72457e972cc35e0d4512ac280a9afbd6837e61aee9502b8e5c2ddedbe0f05c84e13af309c7a5058612420ff
+  languageName: node
+  linkType: hard
+
+"@zag-js/navigation-menu@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/navigation-menu@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/cd4616a7207ead4f43235fb63be61b1bb0adfd7bbacc6e18f752aed2af79f76157304986a3745e3bdf9f2de8266175b3a81c71f0b883ce3ef1134dd9f545a233
+  languageName: node
+  linkType: hard
+
+"@zag-js/number-input@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/number-input@npm:1.40.0"
+  dependencies:
+    "@internationalized/number": "npm:3.6.5"
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/de52246124182155e2a95fb1dd5433406493499ac84db115d0f4d39540cb67fbe88cf81f4442bfa91d595836ed7c51d02d94602cb5e78b2df33700cfbab71300
+  languageName: node
+  linkType: hard
+
+"@zag-js/pagination@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/pagination@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/0cbfef873ba7d59842c654107738fe840ea3a9c45acfb87199c946bbd9030cd36f5bcb2ad03c542ff3fd573b4728dc47b6729665af8f7c5abd968de44898bfcd
+  languageName: node
+  linkType: hard
+
+"@zag-js/password-input@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/password-input@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/adb063b4d4e56dc00a118f56935d102ca552c53f5b274055f85693d4837ab667bcbc73f9b81af64777407e700444e0f4e24a505ce37667aff2f0085b5ad3a286
+  languageName: node
+  linkType: hard
+
+"@zag-js/pin-input@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/pin-input@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/5ea966028c7a115c65881ffbec3a986b4fa6c1c61b2df5ded52141eacbf250e16e7f2dea1f0f3a4cf766075459b72360d9ab4f39a70f243e4155ebbb26039d00
+  languageName: node
+  linkType: hard
+
+"@zag-js/popover@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/popover@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/aria-hidden": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-trap": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/remove-scroll": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/dd3091ed932145df397b89f77aece0f4f7507b4e69ecfaf992206aefa1c7890bbf13fc5f6923ee4475aea994ba70722d01b931f34c5e3eebe5442f8487f43ae6
+  languageName: node
+  linkType: hard
+
+"@zag-js/popper@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/popper@npm:1.40.0"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.6"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/0c040afb32353a6ebe1fb0f0615a73fa396ae28d5ddfbba4236787a0ba9a6893f3c7d064c870f28e137396b0a2f183db0043278a6b03136b35c037783036ea6d
+  languageName: node
+  linkType: hard
+
+"@zag-js/presence@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/presence@npm:1.40.0"
+  dependencies:
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+  checksum: 10c0/e12c8fe987c71534307966298d2899f4f64209291ecf59eb40ea3bd6e932d30946f476d4e373eab830c944715979a7150123657be4aeaa33665abeabadbe2a24
+  languageName: node
+  linkType: hard
+
+"@zag-js/progress@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/progress@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/b65d79028fa41597465a5cb857021c75fb16f23fe32c58bdb7b9e25cbf0889133828236eba9cc83d68ca5846d14adfade8eccc7433ffbb43170fe044a6dc2326
+  languageName: node
+  linkType: hard
+
+"@zag-js/qr-code@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/qr-code@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+    proxy-memoize: "npm:3.0.1"
+    uqr: "npm:0.1.2"
+  checksum: 10c0/60155896dd295e52e33f524675057edda375f2966778c3f4aa6e37be5edac52097b6650eafddfd3f10552fbf249936875066bf60fb3087561a7b60ae6e0d60d6
+  languageName: node
+  linkType: hard
+
+"@zag-js/radio-group@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/radio-group@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/1466e963ab96967506acffb615c8cd4314d2c79e16ce51445a25ed2bcb0533c54e8635597c8c4e6ca2f46ad5387e4aed358a01063f5e341d83bf82ba4faf0d3a
+  languageName: node
+  linkType: hard
+
+"@zag-js/rating-group@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/rating-group@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/5f9c343d2d5de57d8be66c38677d911c0fb76be1942bc7579a025ebc24b702ff0491470cb25d2401b55c7d9af56ccd88b7b89ea41a15b0e2baed960a683e4256
+  languageName: node
+  linkType: hard
+
+"@zag-js/react@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/react@npm:1.40.0"
+  dependencies:
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/store": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/713f29e7c63c9d8b6a9563dffca026ed56eeafd336e7de9e9b3b93e040faaf5e79793b6ce786c294aef1908764b6e0fb6fbe957badbf6545f6a293af805a689f
+  languageName: node
+  linkType: hard
+
+"@zag-js/rect-utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/rect-utils@npm:1.40.0"
+  checksum: 10c0/0f2e2297755d53c8dc594737bc2d4879145b15456146a69e8b47219eb26053c5f2f98ceab67ffe8fd3c3faa63c3bdf84ec31450e077065d75f02a1235f6b4c40
+  languageName: node
+  linkType: hard
+
+"@zag-js/remove-scroll@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/remove-scroll@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/76d67999dd0d37e804c688719254149d91cdb0fb35a224dd0e2c16ac43d1347d14646c9870b885028ff0cde45f9f85a77d605981ba05f20242141e72afe08e12
+  languageName: node
+  linkType: hard
+
+"@zag-js/scroll-area@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/scroll-area@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/e305e72e65bb157ff9a373e94545ce5998c472a2904124fbd6c94fd35302508018335c6ae17104a5db710279f75c7bfbacb1ce24e06b12e015c3fe74ac1b422d
+  languageName: node
+  linkType: hard
+
+"@zag-js/scroll-snap@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/scroll-snap@npm:1.40.0"
+  dependencies:
+    "@zag-js/dom-query": "npm:1.40.0"
+  checksum: 10c0/7d2edfd99fa0995013a0a39e04de8025eb762456f6212f307a17d3416d7f97ddad3706a1c5eff1d572aee6bf219cc0dbc7ddaabbd71e36496276c04f8e8d7d68
+  languageName: node
+  linkType: hard
+
+"@zag-js/select@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/select@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/collection": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/362d634f0c21fc7e4f9f8fdd6949cc5661538a260bdf2e506574b4f4465c15b766cb8f3011a11232362e7eb9f84e745933fc8eddfa002969f2fc0f0e9be1eeef
+  languageName: node
+  linkType: hard
+
+"@zag-js/signature-pad@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/signature-pad@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+    perfect-freehand: "npm:^1.2.3"
+  checksum: 10c0/fba9b8bfd78fd7e645f107f57077d69520853895ceede25ac6fe3dcf0820c4c2e9967768da2f353116fc6e6347c900a743631e4f85d0c282abe03f08239010ce
+  languageName: node
+  linkType: hard
+
+"@zag-js/slider@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/slider@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/900fa4fe93176c38acf45916121055a66ff2bc5ac6150cbc73793fbb65f480e9ffa4ed3a37e4f0281b2ebed44dde0daa8282bc26305080868e74011e60c4b601
+  languageName: node
+  linkType: hard
+
+"@zag-js/splitter@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/splitter@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/b39084153672e711a0acf46850fe65b8c901ee8a9a42111b4ab3394dd1d9782ab5de1681085234297a43ba8f330a50d6ca615b4875490e862935e74b08f09427
+  languageName: node
+  linkType: hard
+
+"@zag-js/steps@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/steps@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/c1b19bb245aaf60800ee6065f5803e0ecddddf883bad3a50abb2711648143e3b112a4e1196a27d6462d5c51357fac5755eb6d9bdfe9fd4a60d4c927f8a668f65
+  languageName: node
+  linkType: hard
+
+"@zag-js/store@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/store@npm:1.40.0"
+  dependencies:
+    proxy-compare: "npm:3.0.1"
+  checksum: 10c0/bc43de9c48b0e965ad7b377090a3800cefb2cab01e88581e10f2514ee1b8da23ab70bfdef0ab6d611ba00a35033efb83e22058a43aab4ec739a66584fa727554
+  languageName: node
+  linkType: hard
+
+"@zag-js/switch@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/switch@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/86293ebd1533232fe7b313607df3428092a6b6b15f3c4ba7cde137f11d2b6cfb2567921d7aa43234f1d678a04ebab920374807af83c382dcbad311f98555642f
+  languageName: node
+  linkType: hard
+
+"@zag-js/tabs@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/tabs@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/b59d1f6ae774be984b68e3aa25a8b7018b5c05ba647dbc53a377015b3e9244110bdf2993cd70ba2201838601db6df0f58f0d59079da431326be2cb695408ddf6
+  languageName: node
+  linkType: hard
+
+"@zag-js/tags-input@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/tags-input@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/auto-resize": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/interact-outside": "npm:1.40.0"
+    "@zag-js/live-region": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/650a1c5bdfb5a59229aed6904a90f9d3c67926802632e05759ab21fac7b02ff1460bb34fd4093d520ec0ff035063057edc30e0e952d512dc7944e09e50601751
+  languageName: node
+  linkType: hard
+
+"@zag-js/timer@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/timer@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/aa3eb5e427802c74e4fc3e836bba0bd4356cd9cfde7e600d54cfbf02d25b5df165a577b2c1dc6315d8855f2fb2ffdcdc1547bca68dfee9d3e08f978f1e66f59c
+  languageName: node
+  linkType: hard
+
+"@zag-js/toast@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/toast@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/32a43331500b77116a5eb625ee91ed180f08a498a49bd6b5a8247db1acbac16b039b64ee8abda09d7797cd3c2fe76e2560c7d0770d29d33b6e41efb46b98ee10
+  languageName: node
+  linkType: hard
+
+"@zag-js/toggle-group@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/toggle-group@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/59dbccafbe15514545ff8e6a2f03d3d3201ad30dc243f6d69cef287de8958032e6667f61bddc546b24281dcd83c939f14416e8993c023ffdb399610ecdb44879
+  languageName: node
+  linkType: hard
+
+"@zag-js/toggle@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/toggle@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/efe07fe7fc9b8d89c9892974b41cf1c0428bd305790334559899bcc417ca99ac815819b7fb879c07a213fb0ea43905f5d6c1bb130588085c0c02743b1535b305
+  languageName: node
+  linkType: hard
+
+"@zag-js/tooltip@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/tooltip@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-visible": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/9c08fb145ea7380a6abf42b1e37ffe7a2191e82d5c4c554e1148a4035ba26372f56d246fa7bd99bea267b08f05482235b89932e4ef615b38e0ce671eafacd5bb
+  languageName: node
+  linkType: hard
+
+"@zag-js/tour@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/tour@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dismissable": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/focus-trap": "npm:1.40.0"
+    "@zag-js/interact-outside": "npm:1.40.0"
+    "@zag-js/popper": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/ad7060ce7e255fe9030e26fbe0e99d79a75ef7d4bf8020fcdfacb3a484b3eefe392017e07a829382cd8e0f9c948354ed7a937654d52881b743676f350f5f21d8
+  languageName: node
+  linkType: hard
+
+"@zag-js/tree-view@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/tree-view@npm:1.40.0"
+  dependencies:
+    "@zag-js/anatomy": "npm:1.40.0"
+    "@zag-js/collection": "npm:1.40.0"
+    "@zag-js/core": "npm:1.40.0"
+    "@zag-js/dom-query": "npm:1.40.0"
+    "@zag-js/types": "npm:1.40.0"
+    "@zag-js/utils": "npm:1.40.0"
+  checksum: 10c0/57c4213a6c995779b0fde7d9203aa7ecbd4ac36e180aac5d887c3e7b44894f7e19315886efd0dafec76a1efcda39744d9daff02122a70914715fc6bd9342d121
+  languageName: node
+  linkType: hard
+
+"@zag-js/types@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/types@npm:1.40.0"
+  dependencies:
+    csstype: "npm:3.2.3"
+  checksum: 10c0/2cfa8834c2b60f9b3625233b6e6d0be4a9154a4635f7a0c1d63f16517160ad41feea7954215021827cbb3ffacca2efb3f92caf2e7f388a9f40b11847ebd4d63a
+  languageName: node
+  linkType: hard
+
+"@zag-js/utils@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@zag-js/utils@npm:1.40.0"
+  checksum: 10c0/203b75618a594afa9a11a5726947d7d1f098f690525a1532324ca58b058bc5e8a01a61e578086fbfecb49e1a9b83fb0ec8098790f944ade30ead3ef6582241e5
   languageName: node
   linkType: hard
 
@@ -10065,6 +11158,13 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
+  languageName: node
+  linkType: hard
+
+"csstype@npm:3.2.3, csstype@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "csstype@npm:3.2.3"
+  checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
   languageName: node
   linkType: hard
 
@@ -11731,7 +12831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^11.15.0":
+"framer-motion@npm:^11.0.0, framer-motion@npm:^11.15.0":
   version: 11.18.2
   resolution: "framer-motion@npm:11.18.2"
   dependencies:
@@ -14550,6 +15650,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-chakra-v3@workspace:examples/next-chakra-v3":
+  version: 0.0.0-use.local
+  resolution: "next-chakra-v3@workspace:examples/next-chakra-v3"
+  dependencies:
+    "@chakra-ui/react": "npm:^3.26.0"
+    "@emotion/react": "npm:^11.14.0"
+    "@emotion/styled": "npm:^11.14.0"
+    "@tanstack/react-query": "npm:^5.64.2"
+    "@types/node": "npm:^20"
+    "@types/react": "npm:^18"
+    "@types/react-dom": "npm:^18"
+    "@vechain/vechain-kit": "workspace:*"
+    framer-motion: "npm:^11.0.0"
+    next: "npm:~16.2.3"
+    next-themes: "npm:^0.4.6"
+    react: "npm:^18"
+    react-dom: "npm:^18"
+    react-icons: "npm:^5.4.0"
+    typescript: "npm:5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "next-template@workspace:examples/next-template":
   version: 0.0.0-use.local
   resolution: "next-template@workspace:examples/next-template"
@@ -14568,13 +15690,23 @@ __metadata:
     eslint-config-next: "npm:14.1.4"
     i18next: "npm:^24.2.1"
     i18next-browser-languagedetector: "npm:^8.0.2"
-    next: "npm:>=15.2.3"
+    next: "npm:~16.2.3"
     react: "npm:^18"
     react-dom: "npm:^18"
     react-i18next: "npm:^15.4.0"
     typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
+
+"next-themes@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "next-themes@npm:0.4.6"
+  peerDependencies:
+    react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+  checksum: 10c0/83590c11d359ce7e4ced14f6ea9dd7a691d5ce6843fe2dc520fc27e29ae1c535118478d03e7f172609c41b1ef1b8da6b8dd2d2acd6cd79cac1abbdbd5b99f2c4
+  languageName: node
+  linkType: hard
 
 "next@npm:15.5.9":
   version: 15.5.9
@@ -15315,6 +16447,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"perfect-freehand@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "perfect-freehand@npm:1.2.3"
+  checksum: 10c0/89005beef0bd99258eb924046927201e26cafd0bd9c47eb30f4559d31be966d69c01382d1bdd09757a2912ff446f6bf0eadc87a1d53425aff07b449b3cb151fa
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -15708,7 +16847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-compare@npm:^3.0.1":
+"proxy-compare@npm:3.0.1, proxy-compare@npm:^3.0.0, proxy-compare@npm:^3.0.1":
   version: 3.0.1
   resolution: "proxy-compare@npm:3.0.1"
   checksum: 10c0/1e3631ef32603d4de263860ce02d84b48384dce9b62238b2148b3c58a4e4ec5b06644615dcc196a339f73b9695443317099d55a9173e02ce8492088c9330c00b
@@ -15719,6 +16858,15 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"proxy-memoize@npm:3.0.1":
+  version: 3.0.1
+  resolution: "proxy-memoize@npm:3.0.1"
+  dependencies:
+    proxy-compare: "npm:^3.0.0"
+  checksum: 10c0/cfdd442365fb7081dcba427ded75a8a9b68af17e72eef8098aa2e6d625914ac4152021832c631f071660d2f61ec18aaaa07ec77142abaa50b12dcaa845de8e4c
   languageName: node
   linkType: hard
 
@@ -18427,6 +19575,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uqr@npm:0.1.2":
+  version: 0.1.2
+  resolution: "uqr@npm:0.1.2"
+  checksum: 10c0/40cd81b4c13f1764d52ec28da2d58e60816e6fae54d4eb75b32fbf3137937f438eff16c766139fb0faec5d248a5314591f5a0dbd694e569d419eed6f3bd80242
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -18686,7 +19841,7 @@ __metadata:
     eslint-config-next: "npm:14.1.4"
     i18next: "npm:^24.2.1"
     i18next-browser-languagedetector: "npm:^8.0.2"
-    next: "npm:>=15.2.3"
+    next: "npm:~16.2.3"
     react: "npm:^18"
     react-dom: "npm:^18"
     react-i18next: "npm:^15.4.0"
@@ -18713,7 +19868,7 @@ __metadata:
     eslint-config-next: "npm:14.1.4"
     i18next: "npm:^24.2.1"
     i18next-browser-languagedetector: "npm:^8.0.2"
-    next: "npm:>=15.2.3"
+    next: "npm:~16.2.3"
     react: "npm:^18"
     react-dom: "npm:^18"
     react-i18next: "npm:^15.4.0"


### PR DESCRIPTION
## Summary

When the user clicks **"Continue with VeWorld"** without the extension installed, the modal previously showed the error view (\`"VeWorld Extension is not installed"\` thrown by dapp-kit's \`setSource('veworld')\`). dapp-kit's own UI doesn't do that — it redirects to a VeWorld Universal Link so the dApp opens inside VeWorld mobile on phones, or lands on the install page on desktop.

This PR mirrors that fallback in \`useConnectWithDappKitSource\`:

\`\`\`ts
if (source === 'veworld' && !window.vechain) {
  window.open(
    \`https://www.veworld.com/discover/browser/ul/\${encodeURIComponent(window.location.href)}\`,
    '_self',
  );
  return;
}
\`\`\`

Also bumps to **v2.8.2** so the brand-lock fix from commit \`5cbd3d76\` (already on main but only in unreleased state) + this deeplink fix can ship together.

## Test plan

- [ ] Desktop **without** the VeWorld extension → click "Continue with VeWorld" → the current tab navigates to the VeWorld install/landing page instead of showing the in-modal error.
- [ ] Mobile (iOS / Android) **without** VeWorld installed → click "Continue with VeWorld" → lands on \`veworld.com\` install page.
- [ ] Mobile **with** VeWorld installed → click "Continue with VeWorld" → opens VeWorld mobile's in-app browser at the dApp URL (Universal Link).
- [ ] Desktop **with** the extension → no change — extension popup still triggers as before.
- [ ] \`yarn kit:typecheck && yarn lint\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new example project demonstrating VeChain Kit integration with Chakra UI v3 and theme management with next-themes.

* **Improvements**
  * Enhanced VeWorld connection flow with automatic fallback to universal link when the extension is unavailable.

* **Chores**
  * Updated Next.js dependency to v16.2.3 across example projects.
  * Bumped VeChain Kit to v2.8.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/vechain-kit/pull/615)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->