### PR TITLE
fix(currency): use narrow symbol so non-EN locales show $ not USD

### DIFF
--- a/packages/vechain-kit/src/utils/currencyUtils.ts
+++ b/packages/vechain-kit/src/utils/currencyUtils.ts
@@ -25,6 +25,7 @@ export const formatCurrencyValue = (
 ): string => {
     const defaultOptions: Intl.NumberFormatOptions = {
         style: 'currency',
+        currencyDisplay: 'narrowSymbol',
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
         currency: options?.currency ?? 'usd',


### PR DESCRIPTION
## Summary
- `Intl.NumberFormat` in non-US locales (e.g. `it-IT`) renders USD as `"1,23 USD"` because `$` is ambiguous outside the US. The wider `USD` glyph overflows several balance/price components.
- Pass `currencyDisplay: 'narrowSymbol'` in `formatCurrencyValue` so the compact symbol is used regardless of locale, while locale number grouping and symbol placement are preserved.
- Applies to every caller of `formatCurrencyValue` / `formatCompactCurrency` (AssetButton, useTotalBalance, AssetsHeader, TokenDetailContent, …).

### Before / after
| Locale | Currency | Before | After |
| --- | --- | --- | --- |
| `it-IT` | USD | `1,23 USD` | `1,23 $` |
| `de-DE` | EUR | `1,23 €` | `1,23 €` (unchanged) |
| `en-US` | USD | `$1.23` | `$1.23` (unchanged) |

## Test plan
- [ ] Switch language to Italian in the account modal and verify USD balances render with `$` and no longer overflow.
- [ ] Repeat for at least one other non-English locale (e.g. French, Spanish).
- [ ] Verify EUR and GBP currencies still render with `€` / `£` across locales.
- [ ] Verify English (US) display is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)