### PR TITLE
fix(staking): stop showing $0 in StarGate/Juicy/BetterSwap cards

### DIFF
--- a/packages/vechain-kit/src/hooks/api/staking/useBetterSwapLpPositions.ts
+++ b/packages/vechain-kit/src/hooks/api/staking/useBetterSwapLpPositions.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useThor } from '@vechain/dapp-kit-react';
 import { formatUnits } from 'ethers';
@@ -30,6 +31,8 @@ export type LpPosition = {
     valueUsd: number;
     valueInCurrency: number;
 };
+
+type LpRawPosition = Omit<LpPosition, 'valueUsd' | 'valueInCurrency'>;
 
 const ERC20_MINI_ABI = [
     {
@@ -112,7 +115,7 @@ export const useBetterSwapLpPositions = (address?: string) => {
         ],
         enabled,
         staleTime: 60_000,
-        queryFn: async (): Promise<LpPosition[]> => {
+        queryFn: async (): Promise<LpRawPosition[]> => {
             if (!address || !pairs.length) return [];
 
             const pairAbi = UniswapV2Pair__factory.abi;
@@ -196,7 +199,7 @@ export const useBetterSwapLpPositions = (address?: string) => {
                 });
             }
 
-            const positions: LpPosition[] = [];
+            const rawPositions: LpRawPosition[] = [];
             for (let i = 0; i < ownedIndexes.length; i++) {
                 const pairIndex = ownedIndexes[i];
                 const pairAddress = validPairs[pairIndex];
@@ -219,16 +222,7 @@ export const useBetterSwapLpPositions = (address?: string) => {
                 const amount0 = Number(formatUnits(reserve0, 18)) * share;
                 const amount1 = Number(formatUnits(reserve1, 18)) * share;
 
-                const price0 = prices[token0Addr.toLowerCase()] || 0;
-                const price1 = prices[token1Addr.toLowerCase()] || 0;
-                const valueUsd = amount0 * price0 + amount1 * price1;
-                const valueInCurrency = convertToSelectedCurrency(
-                    valueUsd,
-                    currentCurrency as SupportedCurrency,
-                    exchangeRates,
-                );
-
-                positions.push({
+                rawPositions.push({
                     pairAddress,
                     lpBalance: lpBalanceFormatted,
                     sharePct: share * 100,
@@ -244,16 +238,34 @@ export const useBetterSwapLpPositions = (address?: string) => {
                             symbolByAddr.get(token1Addr.toLowerCase()) ?? '',
                         amount: amount1,
                     },
-                    valueUsd,
-                    valueInCurrency,
                 });
             }
 
-            return positions;
+            return rawPositions;
         },
     });
 
-    const positions = query.data ?? [];
+    // USD/currency derived from live prices so a late-arriving price query
+    // repopulates values without re-running the on-chain query.
+    const positions = useMemo<LpPosition[]>(() => {
+        const raw = query.data ?? [];
+        return raw.map((p) => {
+            const price0 = prices[p.token0.address.toLowerCase()] || 0;
+            const price1 = prices[p.token1.address.toLowerCase()] || 0;
+            const valueUsd =
+                p.token0.amount * price0 + p.token1.amount * price1;
+            return {
+                ...p,
+                valueUsd,
+                valueInCurrency: convertToSelectedCurrency(
+                    valueUsd,
+                    currentCurrency as SupportedCurrency,
+                    exchangeRates,
+                ),
+            };
+        });
+    }, [query.data, prices, currentCurrency, exchangeRates]);
+
     const totalValueUsd = positions.reduce((acc, p) => acc + p.valueUsd, 0);
     const totalValueInCurrency = positions.reduce(
         (acc, p) => acc + p.valueInCurrency,

--- a/packages/vechain-kit/src/hooks/api/staking/useJuicyPosition.ts
+++ b/packages/vechain-kit/src/hooks/api/staking/useJuicyPosition.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useThor } from '@vechain/dapp-kit-react';
 import { formatUnits } from 'ethers';
@@ -30,6 +31,11 @@ export type JuicyAssetPosition = {
     valueUsd: number;
     valueInCurrency: number;
 };
+
+type JuicyRawAssetPosition = Omit<
+    JuicyAssetPosition,
+    'valueUsd' | 'valueInCurrency'
+>;
 
 export type JuicyPositionResult = {
     supplied: JuicyAssetPosition[];
@@ -71,8 +77,8 @@ export const useJuicyPosition = (address?: string): JuicyPositionResult => {
         queryFn: async () => {
             if (!address || !poolAddress) {
                 return {
-                    supplied: [] as JuicyAssetPosition[],
-                    borrowed: [] as JuicyAssetPosition[],
+                    supplied: [] as JuicyRawAssetPosition[],
+                    borrowed: [] as JuicyRawAssetPosition[],
                     healthFactor: null as number | null,
                 };
             }
@@ -87,8 +93,8 @@ export const useJuicyPosition = (address?: string): JuicyPositionResult => {
 
             if (!reserveList.length) {
                 return {
-                    supplied: [] as JuicyAssetPosition[],
-                    borrowed: [] as JuicyAssetPosition[],
+                    supplied: [] as JuicyRawAssetPosition[],
+                    borrowed: [] as JuicyRawAssetPosition[],
                     healthFactor: null as number | null,
                 };
             }
@@ -204,8 +210,8 @@ export const useJuicyPosition = (address?: string): JuicyPositionResult => {
                 }),
             );
 
-            const supplied: JuicyAssetPosition[] = [];
-            const borrowed: JuicyAssetPosition[] = [];
+            const supplied: JuicyRawAssetPosition[] = [];
+            const borrowed: JuicyRawAssetPosition[] = [];
 
             for (let i = 0; i < tokens.length; i++) {
                 const asset = tokens[i].asset;
@@ -214,43 +220,24 @@ export const useJuicyPosition = (address?: string): JuicyPositionResult => {
                     symbol: asset.slice(0, 6),
                     decimals: 18,
                 };
-                const priceUsd = prices[lower] ?? prices[asset] ?? 0;
 
                 const aBal = supplyRaw[i];
                 if (aBal > 0n) {
-                    const amount = Number(formatUnits(aBal, meta.decimals));
-                    const valueUsd = amount * priceUsd;
                     supplied.push({
                         asset,
                         symbol: meta.symbol,
                         decimals: meta.decimals,
-                        amount,
-                        valueUsd,
-                        valueInCurrency: convertToSelectedCurrency(
-                            valueUsd,
-                            currentCurrency as SupportedCurrency,
-                            exchangeRates,
-                        ),
+                        amount: Number(formatUnits(aBal, meta.decimals)),
                     });
                 }
 
                 const debtRaw = variableDebtRaw[i] + stableDebtRaw[i];
                 if (debtRaw > 0n) {
-                    const amount = Number(
-                        formatUnits(debtRaw, meta.decimals),
-                    );
-                    const valueUsd = amount * priceUsd;
                     borrowed.push({
                         asset,
                         symbol: meta.symbol,
                         decimals: meta.decimals,
-                        amount,
-                        valueUsd,
-                        valueInCurrency: convertToSelectedCurrency(
-                            valueUsd,
-                            currentCurrency as SupportedCurrency,
-                            exchangeRates,
-                        ),
+                        amount: Number(formatUnits(debtRaw, meta.decimals)),
                     });
                 }
             }
@@ -272,8 +259,31 @@ export const useJuicyPosition = (address?: string): JuicyPositionResult => {
     });
 
     const data = query.data;
-    const supplied = data?.supplied ?? [];
-    const borrowed = data?.borrowed ?? [];
+
+    // USD/currency derived from live prices so a late-arriving price query
+    // repopulates values without re-running the on-chain query.
+    const { supplied, borrowed } = useMemo(() => {
+        const enrich = (raw: JuicyRawAssetPosition[]): JuicyAssetPosition[] =>
+            raw.map((p) => {
+                const lower = p.asset.toLowerCase();
+                const priceUsd = prices[lower] ?? prices[p.asset] ?? 0;
+                const valueUsd = p.amount * priceUsd;
+                return {
+                    ...p,
+                    valueUsd,
+                    valueInCurrency: convertToSelectedCurrency(
+                        valueUsd,
+                        currentCurrency as SupportedCurrency,
+                        exchangeRates,
+                    ),
+                };
+            });
+        return {
+            supplied: enrich(data?.supplied ?? []),
+            borrowed: enrich(data?.borrowed ?? []),
+        };
+    }, [data, prices, currentCurrency, exchangeRates]);
+
     const totalSuppliedUsd = supplied.reduce((s, p) => s + p.valueUsd, 0);
     const totalSuppliedInCurrency = supplied.reduce(
         (s, p) => s + p.valueInCurrency,

--- a/packages/vechain-kit/src/hooks/api/staking/useStargatePositions.ts
+++ b/packages/vechain-kit/src/hooks/api/staking/useStargatePositions.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useThor } from '@vechain/dapp-kit-react';
 import { formatUnits } from 'ethers';
@@ -23,6 +24,11 @@ export type StargatePosition = {
     valueInCurrency: number;
     isDelegated: boolean;
 };
+
+type StargateRawPosition = Omit<
+    StargatePosition,
+    'valueUsd' | 'valueInCurrency'
+>;
 
 export type StargatePositionsResult = {
     positions: StargatePosition[];
@@ -60,7 +66,7 @@ export const useStargatePositions = (
         ],
         enabled,
         staleTime: 60_000,
-        queryFn: async (): Promise<StargatePosition[]> => {
+        queryFn: async (): Promise<StargateRawPosition[]> => {
             if (!address) return [];
 
             const nftAbi = StargateNFT__factory.abi;
@@ -108,7 +114,7 @@ export const useStargatePositions = (
                 ]),
             });
 
-            const positions: StargatePosition[] = [];
+            const rawPositions: StargateRawPosition[] = [];
             for (let i = 0; i < tokenIds.length; i++) {
                 const tokenStruct = detailsRes[i * 2] as unknown as {
                     tokenId: bigint;
@@ -120,30 +126,41 @@ export const useStargatePositions = (
                 );
 
                 const vetAmountStaked = tokenStruct.vetAmountStaked.toString();
-                const vetFormatted = Number(formatUnits(tokenStruct.vetAmountStaked, 18));
-                const valueUsd = vetFormatted * vetPriceUsd;
-                const valueInCurrency = convertToSelectedCurrency(
-                    valueUsd,
-                    currentCurrency as SupportedCurrency,
-                    exchangeRates,
+                const vetFormatted = Number(
+                    formatUnits(tokenStruct.vetAmountStaked, 18),
                 );
 
-                positions.push({
+                rawPositions.push({
                     tokenId: tokenStruct.tokenId.toString(),
                     levelId: Number(tokenStruct.levelId),
                     vetAmountStaked,
                     vetAmountFormatted: vetFormatted,
-                    valueUsd,
-                    valueInCurrency,
                     isDelegated: delegationStatus !== 0,
                 });
             }
 
-            return positions;
+            return rawPositions;
         },
     });
 
-    const positions = query.data ?? [];
+    // USD/currency are derived from live prices so a late-arriving price
+    // query repopulates values without re-running the on-chain query.
+    const positions = useMemo<StargatePosition[]>(() => {
+        const raw = query.data ?? [];
+        return raw.map((p) => {
+            const valueUsd = p.vetAmountFormatted * vetPriceUsd;
+            return {
+                ...p,
+                valueUsd,
+                valueInCurrency: convertToSelectedCurrency(
+                    valueUsd,
+                    currentCurrency as SupportedCurrency,
+                    exchangeRates,
+                ),
+            };
+        });
+    }, [query.data, vetPriceUsd, currentCurrency, exchangeRates]);
+
     const totalVet = positions.reduce((acc, p) => acc + p.vetAmountFormatted, 0);
     const totalValueUsd = positions.reduce((acc, p) => acc + p.valueUsd, 0);
     const totalValueInCurrency = positions.reduce(


### PR DESCRIPTION
## Summary

- StarGate, Juicy Finance, and BetterSwap LP cards in the Assets → Staking tab intermittently rendered `$0` even when the user had open positions. Refreshing sometimes resolved it, sometimes didn't.
- Root cause: `valueUsd` was computed *inside* each hook's React Query `queryFn`, while token prices come from a separate query that wasn't in the staking query key. When the staking call resolved before prices loaded, `$0` got baked into the cached result and stuck for the full 60s `staleTime`.
- Fix: `queryFn` now returns only raw on-chain data (amounts, decimals, delegation, etc.). `valueUsd` / `valueInCurrency` are derived in a `useMemo` from live `prices` / `exchangeRates` / `currentCurrency`, so a late-arriving price query repopulates values without re-running the on-chain calls. This matches the pattern `useNavigatorPosition` was already using.

Files: `useStargatePositions.ts`, `useJuicyPosition.ts`, `useBetterSwapLpPositions.ts`.

## Test plan

- [ ] Open Account modal → Assets → Staking tab with a fresh page load (cold price cache). StarGate, Juicy Finance, and BetterSwap LP cards should show non-zero USD values once prices load, without needing a refresh.
- [ ] Switch currency (USD → EUR/GBP). Values update without re-fetching on-chain data.
- [ ] Verify Navigators card still works (unchanged code path).
- [ ] `yarn kit:typecheck` and `yarn lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)