### PR TITLE
chore(cross-app): rebrand 'VeChain Cross-App Connect' → 'VeChain Connect'

### DIFF
--- a/cross-app-connect/src/app/i18n/locales/de.json
+++ b/cross-app-connect/src/app/i18n/locales/de.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Anfrage konnte nicht geladen werden",
             "logIn": "In dein Wallet einloggen",
             "connectTo": "Mit {{app}} verbinden",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-Host für die App-übergreifenden Verbindungs- und Transaktionsflüsse von Privy.",
         "routes": "Routen",
         "connectDesc": "bearbeitet Verbindungsanfragen",

--- a/cross-app-connect/src/app/i18n/locales/en.json
+++ b/cross-app-connect/src/app/i18n/locales/en.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Couldn't load request",
             "logIn": "Log in to your wallet",
             "connectTo": "Connect to {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel host for Privy cross-app connection and transaction flows.",
         "routes": "Routes",
         "connectDesc": "handles connection requests",

--- a/cross-app-connect/src/app/i18n/locales/es.json
+++ b/cross-app-connect/src/app/i18n/locales/es.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "No se pudo cargar la solicitud",
             "logIn": "Inicia sesión en tu wallet",
             "connectTo": "Conectar con {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host de marca blanca para los flujos de conexión y transacción cross-app de Privy.",
         "routes": "Rutas",
         "connectDesc": "gestiona solicitudes de conexión",

--- a/cross-app-connect/src/app/i18n/locales/fr.json
+++ b/cross-app-connect/src/app/i18n/locales/fr.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Impossible de charger la requête",
             "logIn": "Connectez-vous à votre wallet",
             "connectTo": "Se connecter à {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Hôte whitelabel pour les flux de connexion et de transaction cross-app Privy.",
         "routes": "Routes",
         "connectDesc": "gère les requêtes de connexion",

--- a/cross-app-connect/src/app/i18n/locales/hi.json
+++ b/cross-app-connect/src/app/i18n/locales/hi.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "अनुरोध लोड नहीं हो सका",
             "logIn": "अपने वॉलेट में लॉग इन करें",
             "connectTo": "{{app}} से कनेक्ट करें",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy क्रॉस-ऐप कनेक्शन और ट्रांज़ैक्शन फ़्लो के लिए व्हाइटलेबल होस्ट।",
         "routes": "रूट्स",
         "connectDesc": "कनेक्शन अनुरोधों को संभालता है",

--- a/cross-app-connect/src/app/i18n/locales/it.json
+++ b/cross-app-connect/src/app/i18n/locales/it.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Impossibile caricare la richiesta",
             "logIn": "Accedi al tuo wallet",
             "connectTo": "Connetti a {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host whitelabel per i flussi di connessione e transazione cross-app di Privy.",
         "routes": "Route",
         "connectDesc": "gestisce le richieste di connessione",

--- a/cross-app-connect/src/app/i18n/locales/ja.json
+++ b/cross-app-connect/src/app/i18n/locales/ja.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "リクエストを読み込めませんでした",
             "logIn": "ウォレットにログイン",
             "connectTo": "{{app}} に接続",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy のクロスアプリ接続およびトランザクションフロー用のホワイトレーベルホストです。",
         "routes": "ルート",
         "connectDesc": "接続リクエストを処理",

--- a/cross-app-connect/src/app/i18n/locales/ko.json
+++ b/cross-app-connect/src/app/i18n/locales/ko.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "요청을 불러올 수 없습니다",
             "logIn": "지갑에 로그인",
             "connectTo": "{{app}} 에 연결",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy 의 크로스 앱 연결 및 트랜잭션 플로우를 위한 화이트 라벨 호스트입니다.",
         "routes": "경로",
         "connectDesc": "연결 요청 처리",

--- a/cross-app-connect/src/app/i18n/locales/nl.json
+++ b/cross-app-connect/src/app/i18n/locales/nl.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Verzoek kon niet worden geladen",
             "logIn": "Log in op je wallet",
             "connectTo": "Verbinden met {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-host voor Privy's cross-app verbindings- en transactiestromen.",
         "routes": "Routes",
         "connectDesc": "behandelt verbindingsverzoeken",

--- a/cross-app-connect/src/app/i18n/locales/pt.json
+++ b/cross-app-connect/src/app/i18n/locales/pt.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Não foi possível carregar o pedido",
             "logIn": "Inicia sessão na tua wallet",
             "connectTo": "Ligar a {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host whitelabel para os fluxos de ligação e transação cross-app do Privy.",
         "routes": "Rotas",
         "connectDesc": "trata pedidos de ligação",

--- a/cross-app-connect/src/app/i18n/locales/ro.json
+++ b/cross-app-connect/src/app/i18n/locales/ro.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Cererea nu a putut fi încărcată",
             "logIn": "Conectează-te la portofel",
             "connectTo": "Conectează-te la {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host whitelabel pentru fluxurile Privy cross-app de conectare și tranzacție.",
         "routes": "Rute",
         "connectDesc": "gestionează cererile de conectare",

--- a/cross-app-connect/src/app/i18n/locales/ru.json
+++ b/cross-app-connect/src/app/i18n/locales/ru.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Не удалось загрузить запрос",
             "logIn": "Войдите в свой кошелёк",
             "connectTo": "Подключиться к {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-хост для процессов подключения и транзакций Privy cross-app.",
         "routes": "Маршруты",
         "connectDesc": "обрабатывает запросы подключения",

--- a/cross-app-connect/src/app/i18n/locales/sv.json
+++ b/cross-app-connect/src/app/i18n/locales/sv.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Kunde inte ladda begäran",
             "logIn": "Logga in på din plånbok",
             "connectTo": "Anslut till {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-värd för Privy cross-app anslutnings- och transaktionsflöden.",
         "routes": "Rutter",
         "connectDesc": "hanterar anslutningsbegäranden",

--- a/cross-app-connect/src/app/i18n/locales/tr.json
+++ b/cross-app-connect/src/app/i18n/locales/tr.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "İstek yüklenemedi",
             "logIn": "Cüzdanına giriş yap",
             "connectTo": "{{app}} uygulamasına bağlan",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy uygulamalar arası bağlantı ve işlem akışları için whitelabel host.",
         "routes": "Rotalar",
         "connectDesc": "bağlantı isteklerini yönetir",

--- a/cross-app-connect/src/app/i18n/locales/tw.json
+++ b/cross-app-connect/src/app/i18n/locales/tw.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "無法載入請求",
             "logIn": "登入您的錢包",
             "connectTo": "連線至 {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "用於 Privy 跨應用連線與交易流程的白標宿主。",
         "routes": "路由",
         "connectDesc": "處理連線請求",

--- a/cross-app-connect/src/app/i18n/locales/vi.json
+++ b/cross-app-connect/src/app/i18n/locales/vi.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Không thể tải yêu cầu",
             "logIn": "Đăng nhập vào ví của bạn",
             "connectTo": "Kết nối với {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Máy chủ whitelabel cho các luồng kết nối và giao dịch xuyên ứng dụng của Privy.",
         "routes": "Các tuyến",
         "connectDesc": "xử lý các yêu cầu kết nối",

--- a/cross-app-connect/src/app/i18n/locales/zh.json
+++ b/cross-app-connect/src/app/i18n/locales/zh.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "无法加载请求",
             "logIn": "登录到您的钱包",
             "connectTo": "连接到 {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "用于 Privy 跨应用连接与交易流程的白标宿主。",
         "routes": "路由",
         "connectDesc": "处理连接请求",

--- a/cross-app-connect/src/app/layout.tsx
+++ b/cross-app-connect/src/app/layout.tsx
@@ -12,7 +12,7 @@ import './globals.css';
 const colorModeScript = `(function(){try{var d=window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.dataset.colorMode=d?'dark':'light';}catch(e){document.documentElement.dataset.colorMode='light';}})();`;
 
 export const metadata = {
-    title: 'VeChain Cross-App Connect',
+    title: 'VeChain Connect',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

The cross-app host's deployment target is `connect.vechain.org`, but the user-facing labels still say "VeChain Cross-App Connect" — verbose and inconsistent with the chosen subdomain. Trim to plain "VeChain Connect" on every surface a user actually reads.

## Changes

- **`src/app/layout.tsx`** — HTML `<title>` metadata (browser tab).
- **All 17 locale files** — `connect.title.default` (empty-state header on `/cross-app/connect`) and `landing.title` (landing page heading at `/`). Kept in English across every locale since it's a brand name.

## Not touched (intentional)

Internal technical names stay as `cross-app-*`:
- The `cross-app-connect/` package directory name.
- The `/cross-app/connect` and `/cross-app/transact` route paths.
- The `cross-app-connect-check.yaml` / `cross-app-connect-deploy.yaml` / `cross-app-connect-refresh-app-hub.yaml` workflows.
- Internal comments and code references that describe "cross-app flow" technically.

Those are descriptors of what the host *is* (a whitelabel for Privy's cross-app protocol), not the brand name shown to end users.

## Test plan

- [ ] Open the deployed popup at `https://connect.vechain.org/cross-app/transact?…` (or the GH Pages URL pre-DNS-cutover) and confirm the browser tab title reads "VeChain Connect".
- [ ] Navigate to `/cross-app/connect` directly (no query params) — empty-state header reads "VeChain Connect".
- [ ] Navigate to `/` — landing page heading reads "VeChain Connect".
- [ ] Spot-check in 2-3 non-English locales (set browser to Italian, German, Japanese) — the brand name stays "VeChain Connect", the surrounding copy is still translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)