### PR TITLE
fix(ci): read NEXT_PUBLIC_PRIVY_* from secrets, not vars

### DIFF
--- a/.github/workflows/cross-app-connect-check.yaml
+++ b/.github/workflows/cross-app-connect-check.yaml
@@ -74,6 +74,8 @@ jobs:
                   # popup needs them to construct the Privy client. The build
                   # tolerates missing values but won't run end-to-end without
                   # them — sufficient to verify the bundle compiles cleanly.
-                  NEXT_PUBLIC_PRIVY_APP_ID: ${{ vars.NEXT_PUBLIC_PRIVY_APP_ID }}
-                  NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ vars.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
-                  NEXT_PUBLIC_PRIVY_DOMAIN: ${{ vars.NEXT_PUBLIC_PRIVY_DOMAIN }}
+                  # See `cross-app-connect-deploy.yaml` for the rationale —
+                  # NEXT_PUBLIC_* values live in Secrets on this repo.
+                  NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
+                  NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
+                  NEXT_PUBLIC_PRIVY_DOMAIN: ${{ secrets.NEXT_PUBLIC_PRIVY_DOMAIN }}

--- a/.github/workflows/cross-app-connect-deploy.yaml
+++ b/.github/workflows/cross-app-connect-deploy.yaml
@@ -42,9 +42,13 @@ jobs:
             - name: Build (cross-app-connect)
               run: yarn workspace cross-app-connect build
               env:
-                  NEXT_PUBLIC_PRIVY_APP_ID: ${{ vars.NEXT_PUBLIC_PRIVY_APP_ID }}
-                  NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ vars.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
-                  NEXT_PUBLIC_PRIVY_DOMAIN: ${{ vars.NEXT_PUBLIC_PRIVY_DOMAIN }}
+                  # `NEXT_PUBLIC_*` values end up in the client bundle, so
+                  # they're not actually sensitive — but they're stored on
+                  # this repo as Secrets, so read them from `secrets.*`
+                  # (not `vars.*`) at build time.
+                  NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
+                  NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
+                  NEXT_PUBLIC_PRIVY_DOMAIN: ${{ secrets.NEXT_PUBLIC_PRIVY_DOMAIN }}
                   # Empty when a custom domain is set up in repo Settings →
                   # Pages. Override to `/vechain-kit` (or whatever the repo
                   # name is) if you want to test at the default

--- a/cross-app-connect/src/app/i18n/locales/de.json
+++ b/cross-app-connect/src/app/i18n/locales/de.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Anfrage konnte nicht geladen werden",
             "logIn": "In dein Wallet einloggen",
             "connectTo": "Mit {{app}} verbinden",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-Host für die App-übergreifenden Verbindungs- und Transaktionsflüsse von Privy.",
         "routes": "Routen",
         "connectDesc": "bearbeitet Verbindungsanfragen",

--- a/cross-app-connect/src/app/i18n/locales/en.json
+++ b/cross-app-connect/src/app/i18n/locales/en.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Couldn't load request",
             "logIn": "Log in to your wallet",
             "connectTo": "Connect to {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel host for Privy cross-app connection and transaction flows.",
         "routes": "Routes",
         "connectDesc": "handles connection requests",

--- a/cross-app-connect/src/app/i18n/locales/es.json
+++ b/cross-app-connect/src/app/i18n/locales/es.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "No se pudo cargar la solicitud",
             "logIn": "Inicia sesión en tu wallet",
             "connectTo": "Conectar con {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host de marca blanca para los flujos de conexión y transacción cross-app de Privy.",
         "routes": "Rutas",
         "connectDesc": "gestiona solicitudes de conexión",

--- a/cross-app-connect/src/app/i18n/locales/fr.json
+++ b/cross-app-connect/src/app/i18n/locales/fr.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Impossible de charger la requête",
             "logIn": "Connectez-vous à votre wallet",
             "connectTo": "Se connecter à {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Hôte whitelabel pour les flux de connexion et de transaction cross-app Privy.",
         "routes": "Routes",
         "connectDesc": "gère les requêtes de connexion",

--- a/cross-app-connect/src/app/i18n/locales/hi.json
+++ b/cross-app-connect/src/app/i18n/locales/hi.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "अनुरोध लोड नहीं हो सका",
             "logIn": "अपने वॉलेट में लॉग इन करें",
             "connectTo": "{{app}} से कनेक्ट करें",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy क्रॉस-ऐप कनेक्शन और ट्रांज़ैक्शन फ़्लो के लिए व्हाइटलेबल होस्ट।",
         "routes": "रूट्स",
         "connectDesc": "कनेक्शन अनुरोधों को संभालता है",

--- a/cross-app-connect/src/app/i18n/locales/it.json
+++ b/cross-app-connect/src/app/i18n/locales/it.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Impossibile caricare la richiesta",
             "logIn": "Accedi al tuo wallet",
             "connectTo": "Connetti a {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host whitelabel per i flussi di connessione e transazione cross-app di Privy.",
         "routes": "Route",
         "connectDesc": "gestisce le richieste di connessione",

--- a/cross-app-connect/src/app/i18n/locales/ja.json
+++ b/cross-app-connect/src/app/i18n/locales/ja.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "リクエストを読み込めませんでした",
             "logIn": "ウォレットにログイン",
             "connectTo": "{{app}} に接続",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy のクロスアプリ接続およびトランザクションフロー用のホワイトレーベルホストです。",
         "routes": "ルート",
         "connectDesc": "接続リクエストを処理",

--- a/cross-app-connect/src/app/i18n/locales/ko.json
+++ b/cross-app-connect/src/app/i18n/locales/ko.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "요청을 불러올 수 없습니다",
             "logIn": "지갑에 로그인",
             "connectTo": "{{app}} 에 연결",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy 의 크로스 앱 연결 및 트랜잭션 플로우를 위한 화이트 라벨 호스트입니다.",
         "routes": "경로",
         "connectDesc": "연결 요청 처리",

--- a/cross-app-connect/src/app/i18n/locales/nl.json
+++ b/cross-app-connect/src/app/i18n/locales/nl.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Verzoek kon niet worden geladen",
             "logIn": "Log in op je wallet",
             "connectTo": "Verbinden met {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-host voor Privy's cross-app verbindings- en transactiestromen.",
         "routes": "Routes",
         "connectDesc": "behandelt verbindingsverzoeken",

--- a/cross-app-connect/src/app/i18n/locales/pt.json
+++ b/cross-app-connect/src/app/i18n/locales/pt.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Não foi possível carregar o pedido",
             "logIn": "Inicia sessão na tua wallet",
             "connectTo": "Ligar a {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host whitelabel para os fluxos de ligação e transação cross-app do Privy.",
         "routes": "Rotas",
         "connectDesc": "trata pedidos de ligação",

--- a/cross-app-connect/src/app/i18n/locales/ro.json
+++ b/cross-app-connect/src/app/i18n/locales/ro.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Cererea nu a putut fi încărcată",
             "logIn": "Conectează-te la portofel",
             "connectTo": "Conectează-te la {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Host whitelabel pentru fluxurile Privy cross-app de conectare și tranzacție.",
         "routes": "Rute",
         "connectDesc": "gestionează cererile de conectare",

--- a/cross-app-connect/src/app/i18n/locales/ru.json
+++ b/cross-app-connect/src/app/i18n/locales/ru.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Не удалось загрузить запрос",
             "logIn": "Войдите в свой кошелёк",
             "connectTo": "Подключиться к {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-хост для процессов подключения и транзакций Privy cross-app.",
         "routes": "Маршруты",
         "connectDesc": "обрабатывает запросы подключения",

--- a/cross-app-connect/src/app/i18n/locales/sv.json
+++ b/cross-app-connect/src/app/i18n/locales/sv.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Kunde inte ladda begäran",
             "logIn": "Logga in på din plånbok",
             "connectTo": "Anslut till {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Whitelabel-värd för Privy cross-app anslutnings- och transaktionsflöden.",
         "routes": "Rutter",
         "connectDesc": "hanterar anslutningsbegäranden",

--- a/cross-app-connect/src/app/i18n/locales/tr.json
+++ b/cross-app-connect/src/app/i18n/locales/tr.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "İstek yüklenemedi",
             "logIn": "Cüzdanına giriş yap",
             "connectTo": "{{app}} uygulamasına bağlan",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Privy uygulamalar arası bağlantı ve işlem akışları için whitelabel host.",
         "routes": "Rotalar",
         "connectDesc": "bağlantı isteklerini yönetir",

--- a/cross-app-connect/src/app/i18n/locales/tw.json
+++ b/cross-app-connect/src/app/i18n/locales/tw.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "無法載入請求",
             "logIn": "登入您的錢包",
             "connectTo": "連線至 {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "用於 Privy 跨應用連線與交易流程的白標宿主。",
         "routes": "路由",
         "connectDesc": "處理連線請求",

--- a/cross-app-connect/src/app/i18n/locales/vi.json
+++ b/cross-app-connect/src/app/i18n/locales/vi.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "Không thể tải yêu cầu",
             "logIn": "Đăng nhập vào ví của bạn",
             "connectTo": "Kết nối với {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "Máy chủ whitelabel cho các luồng kết nối và giao dịch xuyên ứng dụng của Privy.",
         "routes": "Các tuyến",
         "connectDesc": "xử lý các yêu cầu kết nối",

--- a/cross-app-connect/src/app/i18n/locales/zh.json
+++ b/cross-app-connect/src/app/i18n/locales/zh.json
@@ -223,7 +223,7 @@
     },
     "connect": {
         "title": {
-            "default": "VeChain Cross-App Connect",
+            "default": "VeChain Connect",
             "couldNotLoad": "无法加载请求",
             "logIn": "登录到您的钱包",
             "connectTo": "连接到 {{app}}",
@@ -272,7 +272,7 @@
         }
     },
     "landing": {
-        "title": "VeChain Cross-App Connect",
+        "title": "VeChain Connect",
         "subtitle": "用于 Privy 跨应用连接与交易流程的白标宿主。",
         "routes": "路由",
         "connectDesc": "处理连接请求",

--- a/cross-app-connect/src/app/layout.tsx
+++ b/cross-app-connect/src/app/layout.tsx
@@ -12,7 +12,7 @@ import './globals.css';
 const colorModeScript = `(function(){try{var d=window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.dataset.colorMode=d?'dark':'light';}catch(e){document.documentElement.dataset.colorMode='light';}})();`;
 
 export const metadata = {
-    title: 'VeChain Cross-App Connect',
+    title: 'VeChain Connect',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

The Privy env config (`NEXT_PUBLIC_PRIVY_APP_ID`, `NEXT_PUBLIC_PRIVY_CLIENT_ID`, `NEXT_PUBLIC_PRIVY_DOMAIN`) is stored on this repo as **Secrets**, but the cross-app-connect deploy workflow was reading them from `vars.*` (repo Variables). That resolves to an empty string at build time → the static export ships with no `appId` → the runtime throws on first load:

```
Uncaught Error: NEXT_PUBLIC_PRIVY_APP_ID is required to bootstrap the cross-app host.
Set it in the environment before building.
```

## Fix

Switch the env injection in both `cross-app-connect-deploy.yaml` (build step) and `cross-app-connect-check.yaml` (PR check step) from `vars.*` to `secrets.*` so they read from the location the values actually live in.

## Note on Secrets vs Variables

`NEXT_PUBLIC_*` values land in the client bundle by design — every visitor of the popup can read them out of the JS bundle. So storing them in Secrets is no more secure than Variables; either works for build-time injection. The workflow just has to match where they're set.

`NEXT_PUBLIC_BASE_PATH` is intentionally left on `vars.*` — it's not sensitive, and it's optional (should be unset once the custom domain is wired).

## Test plan

- [ ] Merge → deploy workflow re-runs → static export rebuilt with `appId` baked in.
- [ ] Visit `https://connect.vechain.org/cross-app/connect?...` — no more "NEXT_PUBLIC_PRIVY_APP_ID is required" thrown on load.
- [ ] Trigger a cross-app login from a kit-using dApp → popup loads, OAuth flow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the product branding from "VeChain Cross-App Connect" to "VeChain Connect" throughout the application UI, page titles, and across all 17 language translations to reflect the updated product identity.
  * Migrated deployment workflows to source configuration parameters from GitHub Secrets instead of GitHub Variables for secure credential and sensitive data management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/vechain-kit/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->