### PR TITLE
fix(generic-delegator): correct gas estimation for smart-account txs

### DIFF
--- a/cross-app-connect/src/app/cross-app/_lib/decoder.ts
+++ b/cross-app-connect/src/app/cross-app/_lib/decoder.ts
@@ -113,6 +113,12 @@ export async function decodeClause(
     thor: ThorClient | null,
     network: NETWORK_TYPE,
     self?: string,
+    /** Lowercased address of the generic delegator's deposit account. When
+     *  set, clauses transferring VET / VTHO / B3TR / VOT3 to this address
+     *  are re-labelled as "Pay transaction fee" instead of an opaque
+     *  "Send X VET to 0x86…fa" — the user understands the clause exists
+     *  to fund the gas payer, not as a separate transfer. */
+    feeDepositAccount?: string,
 ): Promise<DecodedClause> {
     const data = (clause.data ?? '0x').toLowerCase();
     const value = (() => {
@@ -123,9 +129,25 @@ export async function decodeClause(
         }
     })();
 
+    const isFeeDeposit = (recipient: string): boolean =>
+        !!feeDepositAccount &&
+        recipient.toLowerCase() === feeDepositAccount;
+
     // 1. Native VET transfer
     if ((data === '0x' || data === '') && value > ZERO) {
         const amount = formatUnits(value, 18);
+        if (isFeeDeposit(clause.to)) {
+            return {
+                kind: 'known_action',
+                category: 'fee',
+                recipient: clause.to,
+                summary: t('action.fee.payTransactionFee'),
+                detail: t('action.fee.amount', {
+                    amount: trimAmount(amount),
+                    symbol: 'VET',
+                }),
+            };
+        }
         return {
             kind: 'native_transfer',
             recipient: clause.to,
@@ -157,6 +179,18 @@ export async function decodeClause(
                         bigint,
                     ];
                     const amount = formatUnits(raw, token.decimals);
+                    if (isFeeDeposit(recipient)) {
+                        return {
+                            kind: 'known_action',
+                            category: 'fee',
+                            recipient,
+                            summary: t('action.fee.payTransactionFee'),
+                            detail: t('action.fee.amount', {
+                                amount: trimAmount(amount),
+                                symbol: token.symbol,
+                            }),
+                        };
+                    }
                     return {
                         kind: 'token_transfer',
                         recipient,

--- a/cross-app-connect/src/app/cross-app/_lib/knownActions.ts
+++ b/cross-app-connect/src/app/cross-app/_lib/knownActions.ts
@@ -29,7 +29,8 @@ export type KnownActionCategory =
     | 'nft'
     | 'token'
     | 'staking'
-    | 'swap';
+    | 'swap'
+    | 'fee';
 
 /**
  * Structured side-channel that travels alongside the localized summary so

--- a/cross-app-connect/src/app/cross-app/_lib/thor.ts
+++ b/cross-app-connect/src/app/cross-app/_lib/thor.ts
@@ -22,16 +22,47 @@ const NETWORK = {
     main: {
         nodeUrl: 'https://mainnet.vechain.org',
         accountFactoryAddress: '0xC06Ad8573022e2BE416CA89DA47E8c592971679A',
+        genericDelegatorUrl: 'https://mainnet.delegator.vechain.org/api/v1/',
     },
     test: {
         nodeUrl: 'https://testnet.vechain.org',
         accountFactoryAddress: '0x713b908Bcf77f3E00EFEf328E50b657a1A23AeaF',
+        genericDelegatorUrl: 'https://testnet.delegator.vechain.org/api/v1/',
     },
 } as const;
 
 export const networkType = NETWORK_TYPE;
 export const networkConfig = NETWORK[NETWORK_TYPE];
 export const thor = ThorClient.at(networkConfig.nodeUrl);
+
+// Fetch the generic delegator's current deposit account once per page load.
+// The recogniser in decoder.ts uses the result to re-label clauses sending
+// gas tokens to that address as "Pay transaction fee" instead of an opaque
+// "Send X VET to 0x86…fa", so the user understands what they're paying.
+let depositAccountPromise: Promise<string | null> | null = null;
+export async function fetchGenericDelegatorDepositAccount(): Promise<
+    string | null
+> {
+    if (!depositAccountPromise) {
+        depositAccountPromise = (async () => {
+            try {
+                const res = await fetch(
+                    new URL(
+                        'deposit/account',
+                        networkConfig.genericDelegatorUrl,
+                    ),
+                    { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+                );
+                if (!res.ok) return null;
+                const data = (await res.json()) as { depositAccount?: string };
+                return data.depositAccount?.toLowerCase() ?? null;
+            } catch {
+                return null;
+            }
+        })();
+    }
+    return depositAccountPromise;
+}
 
 // Minimal ABI for SocialLoginSmartAccountFactory.getAccountAddress. Inlined
 // to avoid pulling the full `@vechain/vechain-contract-types` package; this

--- a/cross-app-connect/src/app/cross-app/transact/TransactClient.tsx
+++ b/cross-app-connect/src/app/cross-app/transact/TransactClient.tsx
@@ -28,6 +28,7 @@ import {
     type Risk,
 } from '../_lib/labels';
 import {
+    fetchGenericDelegatorDepositAccount,
     getChainId,
     getSmartAccountAddress,
     networkType,
@@ -387,9 +388,21 @@ export function TransactClient() {
         const selfAddress = smartAccount?.address;
         let cancelled = false;
         (async () => {
+            // Resolve the generic delegator's deposit account so transfers
+            // funding the gas payer get re-labelled as "Pay transaction fee".
+            // Cached after the first call; null if the delegator is
+            // unreachable (decoder gracefully falls back to the raw label).
+            const feeDepositAccount =
+                (await fetchGenericDelegatorDepositAccount()) ?? undefined;
             const results = await Promise.all(
                 parsed.clauses.map((c) =>
-                    decodeClause(c, thor, networkType, selfAddress),
+                    decodeClause(
+                        c,
+                        thor,
+                        networkType,
+                        selfAddress,
+                        feeDepositAccount,
+                    ),
                 ),
             );
             if (!cancelled) setDecoded(results);

--- a/cross-app-connect/src/app/i18n/locales/en.json
+++ b/cross-app-connect/src/app/i18n/locales/en.json
@@ -53,6 +53,10 @@
             "native": "Send {{amount}} VET",
             "token": "Send {{amount}} {{symbol}}"
         },
+        "fee": {
+            "payTransactionFee": "Pay transaction fee",
+            "amount": "{{amount}} {{symbol}} to the gas payer"
+        },
         "approve": {
             "unlimited": "Allow unlimited {{symbol}} spending",
             "upTo": "Allow spending up to {{amount}} {{symbol}}"

--- a/cross-app-connect/src/app/i18n/locales/it.json
+++ b/cross-app-connect/src/app/i18n/locales/it.json
@@ -53,6 +53,10 @@
             "native": "Invia {{amount}} VET",
             "token": "Invia {{amount}} {{symbol}}"
         },
+        "fee": {
+            "payTransactionFee": "Paga fee per transazione",
+            "amount": "{{amount}} {{symbol}} al pagatore del gas"
+        },
         "approve": {
             "unlimited": "Consenti spesa illimitata di {{symbol}}",
             "upTo": "Consenti spesa fino a {{amount}} {{symbol}}"

--- a/examples/homepage/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/homepage/src/app/providers/VechainKitProviderWrapper.tsx
@@ -202,9 +202,6 @@ export function VechainKitProviderWrapper({ children }: Props) {
                 // nodeUrl: 'http://localhost:8669',
             }}
             allowCustomTokens={true}
-            feeDelegation={{
-                delegatorUrl: process.env.NEXT_PUBLIC_DELEGATOR_URL!,
-            }}
         >
             <LanguageSync>{children}</LanguageSync>
         </VeChainKitProvider>

--- a/examples/playground/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/playground/src/app/providers/VechainKitProviderWrapper.tsx
@@ -238,9 +238,9 @@ export function VechainKitProviderWrapper({ children }: Props) {
             //     vot3ContractAddress:
             //         '0xf7a08af15cb3501feee53ebe11f4428a966fa459',
             // }}
-            feeDelegation={{
-                delegatorUrl: process.env.NEXT_PUBLIC_DELEGATOR_URL!,
-            }}
+            // feeDelegation={{
+            //     delegatorUrl: process.env.NEXT_PUBLIC_DELEGATOR_URL!,
+            // }}
         >
             <LanguageSync>{children}</LanguageSync>
         </VeChainKitProvider>

--- a/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
@@ -163,7 +163,13 @@ export const ChooseNameSummaryContent = ({
     const [userSelectedGasToken, setUserSelectedGasToken] =
         React.useState<GasTokenType | null>(null);
 
+    // VeChain pays gas for domain claims via the kit-sponsored delegator
+    // (see useClaimVetDomain). Skip the gas-token UI and "do you have
+    // enough VTHO" check so users with no gas tokens can still proceed.
+    const KIT_PAYS_GAS = true;
+
     const shouldEstimateGas =
+        !KIT_PAYS_GAS &&
         preferences.availableGasTokens.length > 0 &&
         (connection.isConnectedWithPrivy ||
             connection.isConnectedWithVeChain) &&
@@ -182,6 +188,7 @@ export const ChooseNameSummaryContent = ({
     });
     const usedGasToken = gasEstimation?.usedToken;
     const disableConfirmButtonDuringEstimation =
+        !KIT_PAYS_GAS &&
         (gasEstimationLoading || !gasEstimation) &&
         connection.isConnectedWithPrivy &&
         !feeDelegation?.delegatorUrl;
@@ -196,7 +203,8 @@ export const ChooseNameSummaryContent = ({
     );
 
     // hasEnoughBalance is now determined by the hook itself
-    const hasEnoughBalance = !!usedGasToken && !gasEstimationError;
+    const hasEnoughBalance =
+        KIT_PAYS_GAS || (!!usedGasToken && !gasEstimationError);
 
     // Auto-fallback: if the selected token cannot cover fees (estimation error),
     // clear selection to re-estimate across all available tokens
@@ -256,7 +264,7 @@ export const ChooseNameSummaryContent = ({
                         </Text>
                     </VStack>
                 )}
-                {connection.isConnectedWithPrivy && (
+                {!KIT_PAYS_GAS && connection.isConnectedWithPrivy && (
                     <GasFeeSummary
                         estimation={gasEstimation}
                         isLoading={gasEstimationLoading}
@@ -291,6 +299,7 @@ export const ChooseNameSummaryContent = ({
                     hasEnoughGasBalance={hasEnoughBalance}
                     isLoadingGasEstimation={gasEstimationLoading}
                     showGasEstimationError={
+                        !KIT_PAYS_GAS &&
                         !feeDelegation?.delegatorUrl &&
                         connection.isConnectedWithPrivy
                     }

--- a/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/ChooseName/ChooseNameSummaryContent.tsx
@@ -163,10 +163,13 @@ export const ChooseNameSummaryContent = ({
     const [userSelectedGasToken, setUserSelectedGasToken] =
         React.useState<GasTokenType | null>(null);
 
-    // VeChain pays gas for domain claims via the kit-sponsored delegator
-    // (see useClaimVetDomain). Skip the gas-token UI and "do you have
-    // enough VTHO" check so users with no gas tokens can still proceed.
-    const KIT_PAYS_GAS = true;
+    // VeChain pays gas for domain CLAIMS via the kit-sponsored delegator
+    // (see useClaimVetDomain / useClaimVeWorldSubdomain). The unset path
+    // (useUnsetDomain) is NOT sponsored — the user pays — so we still
+    // need the gas-token UI and balance check for that case. Drives:
+    // skip estimation, hide GasFeeSummary, force hasEnoughGasBalance,
+    // and suppress gas-estimation errors.
+    const KIT_PAYS_GAS = !isUnsetting;
 
     const shouldEstimateGas =
         !KIT_PAYS_GAS &&

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Profile/Customization/CustomizationSummaryContent.tsx
@@ -207,7 +207,13 @@ export const CustomizationSummaryContent = ({
     const [userSelectedGasToken, setUserSelectedGasToken] =
         React.useState<GasTokenType | null>(null);
 
+    // VeChain pays gas for profile updates via the kit-sponsored delegator
+    // (see useUpdateTextRecord). Skip the gas-token UI and "do you have
+    // enough VTHO" check so users with no gas tokens can still proceed.
+    const KIT_PAYS_GAS = true;
+
     const shouldEstimateGas =
+        !KIT_PAYS_GAS &&
         preferences.availableGasTokens.length > 0 &&
         (connection.isConnectedWithPrivy ||
             connection.isConnectedWithVeChain) &&
@@ -226,6 +232,7 @@ export const CustomizationSummaryContent = ({
     });
     const usedGasToken = gasEstimation?.usedToken;
     const disableConfirmButtonDuringEstimation =
+        !KIT_PAYS_GAS &&
         (gasEstimationLoading || !gasEstimation) &&
         connection.isConnectedWithPrivy &&
         !feeDelegation?.delegatorUrl;
@@ -240,7 +247,8 @@ export const CustomizationSummaryContent = ({
     );
 
     // hasEnoughBalance is now determined by the hook itself
-    const hasEnoughBalance = !!usedGasToken && !gasEstimationError;
+    const hasEnoughBalance =
+        KIT_PAYS_GAS || (!!usedGasToken && !gasEstimationError);
 
     // Auto-fallback: if the selected token cannot cover fees (estimation error),
     // clear selection to re-estimate across all available tokens
@@ -377,7 +385,7 @@ export const CustomizationSummaryContent = ({
                         renderField(t('Website'), changes.website)}
                     {changes.email && renderField(t('Email'), changes.email)}
                 </VStack>
-                {connection.isConnectedWithPrivy && (
+                {!KIT_PAYS_GAS && connection.isConnectedWithPrivy && (
                     <GasFeeSummary
                         estimation={gasEstimation}
                         isLoading={gasEstimationLoading}
@@ -407,6 +415,7 @@ export const CustomizationSummaryContent = ({
                     hasEnoughGasBalance={hasEnoughBalance}
                     isLoadingGasEstimation={gasEstimationLoading}
                     showGasEstimationError={
+                        !KIT_PAYS_GAS &&
                         !feeDelegation?.delegatorUrl &&
                         connection.isConnectedWithPrivy
                     }

--- a/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/SendToken/SendTokenSummaryContent.tsx
@@ -28,6 +28,7 @@ import {
     TokenWithValue,
     useGasTokenSelection,
     useGenericDelegatorFeeEstimation,
+    useEstimateAllTokens,
 } from '@/hooks';
 import { useTranslation } from 'react-i18next';
 import { useVeChainKitConfig } from '@/providers';
@@ -73,6 +74,19 @@ export const SendTokenSummaryContent = ({
     );
     const { open: openUpgradeSmartAccountModal } =
         useUpgradeSmartAccountModal();
+
+    // VeWorld-style "amount adjusted to pay fee" salvage. Initially null.
+    // The auto-adjust useEffect below sets this when the user is trying
+    // to send (almost) their entire balance of a token that's also the
+    // only viable gas token. The effectiveAmount drives the actual
+    // transfer hooks and the gas estimation re-pass, so once we've
+    // dropped to maxSpendable the iteration finds the sending token as
+    // its winner and the tx goes through.
+    const [adjustedAmount, setAdjustedAmount] = React.useState<string | null>(
+        null,
+    );
+    const effectiveAmount = adjustedAmount ?? amount;
+
     // Get the final image URL
     const toImageSrc = useMemo(() => {
         if (avatar) {
@@ -111,9 +125,12 @@ export const SendTokenSummaryContent = ({
                     description: t(
                         '{{amount}} {{symbol}} is on its way to {{recipient}}.',
                         {
-                            amount: Number(amount).toLocaleString(undefined, {
-                                maximumFractionDigits: 6,
-                            }),
+                            amount: Number(effectiveAmount).toLocaleString(
+                                undefined,
+                                {
+                                    maximumFractionDigits: 6,
+                                },
+                            ),
                             symbol: selectedToken.symbol,
                             recipient: recipientLabel,
                         },
@@ -134,7 +151,7 @@ export const SendTokenSummaryContent = ({
             t,
             isolatedView,
             closeAccountModal,
-            amount,
+            effectiveAmount,
             selectedToken.symbol,
             resolvedDomain,
             resolvedAddress,
@@ -154,7 +171,7 @@ export const SendTokenSummaryContent = ({
     } = useTransferERC20({
         fromAddress: account?.address ?? '',
         receiverAddress: resolvedAddress || toAddressOrDomain,
-        amount,
+        amount: effectiveAmount,
         tokenAddress: selectedToken.address,
         tokenName: selectedToken.symbol,
         onError: (error) => {
@@ -172,7 +189,7 @@ export const SendTokenSummaryContent = ({
     } = useTransferVET({
         fromAddress: account?.address ?? '',
         receiverAddress: resolvedAddress || toAddressOrDomain,
-        amount,
+        amount: effectiveAmount,
         onError: (error) => {
             handleError(error ?? '');
         },
@@ -256,8 +273,16 @@ export const SendTokenSummaryContent = ({
         tokens: selectedGasToken
             ? [selectedGasToken]
             : preferences.availableGasTokens, // Use selected token or all available
-        sendingAmount: amount,
+        sendingAmount: effectiveAmount,
         sendingTokenSymbol: selectedToken.symbol,
+        enabled: shouldEstimateGas && !!feeDelegation?.genericDelegatorUrl,
+    });
+
+    // Per-token gas costs (independent of which token the iteration picks),
+    // used by the auto-adjust salvage below.
+    const { data: allTokenCosts } = useEstimateAllTokens({
+        clauses: selectedToken.symbol === 'VET' ? vetClauses : erc20Clauses,
+        tokens: preferences.availableGasTokens,
         enabled: shouldEstimateGas && !!feeDelegation?.genericDelegatorUrl,
     });
     const usedGasToken = gasEstimation?.usedToken;
@@ -287,6 +312,46 @@ export const SendTokenSummaryContent = ({
             setSelectedGasToken(null);
         }
     }, [gasEstimationError, selectedGasToken]);
+
+    // VeWorld-style auto-adjust: when the iteration cannot find any gas
+    // token whose balance covers gas + the sending amount, AND the
+    // sending token is itself one of the available gas tokens with
+    // enough balance for the gas alone, drop the amount down to
+    // (balance - gas * SAFETY_FACTOR) so the tx goes through. Mirrors
+    // veworld-mobile's SummaryScreen.tsx co-spend handling.
+    const ADJUST_SAFETY_FACTOR = 1.05;
+    React.useEffect(() => {
+        // Don't loop: once adjusted, we stop re-evaluating.
+        if (adjustedAmount !== null) return;
+        if (!gasEstimationError) return;
+        if (!allTokenCosts) return;
+        const sendingSymbol = selectedToken.symbol as GasTokenType;
+        if (
+            !preferences.availableGasTokens.includes(sendingSymbol as never)
+        ) {
+            return;
+        }
+        const costEntry = allTokenCosts[sendingSymbol];
+        if (!costEntry || costEntry.loading || costEntry.cost <= 0) return;
+        const balance = Number(selectedToken.balance);
+        const gasReserve = costEntry.cost * ADJUST_SAFETY_FACTOR;
+        const maxSpendable = balance - gasReserve;
+        if (maxSpendable <= 0) return;
+        if (Number(amount) <= maxSpendable) return;
+        // Floor to 4 decimals so the displayed number doesn't show
+        // floating-point noise; the underlying parseUnits handles the
+        // rest at full precision.
+        const rounded = Math.floor(maxSpendable * 10000) / 10000;
+        if (rounded <= 0) return;
+        setAdjustedAmount(rounded.toString());
+    }, [
+        adjustedAmount,
+        gasEstimationError,
+        allTokenCosts,
+        selectedToken,
+        preferences.availableGasTokens,
+        amount,
+    ]);
 
     return (
         <>
@@ -346,6 +411,36 @@ export const SendTokenSummaryContent = ({
                             />
                         )}
 
+                        {adjustedAmount !== null && (
+                            <Box
+                                w="full"
+                                borderRadius="md"
+                                p={3}
+                                borderWidth="1px"
+                                borderColor="vechain-kit-border"
+                                bg="vechain-kit-card"
+                            >
+                                <Text fontSize="sm" color={textPrimary}>
+                                    {t(
+                                        'Amount adjusted from {{original}} to {{adjusted}} {{symbol}} to cover the transaction fee.',
+                                        {
+                                            original: Number(
+                                                amount,
+                                            ).toLocaleString(undefined, {
+                                                maximumFractionDigits: 4,
+                                            }),
+                                            adjusted: Number(
+                                                adjustedAmount,
+                                            ).toLocaleString(undefined, {
+                                                maximumFractionDigits: 4,
+                                            }),
+                                            symbol: selectedToken.symbol,
+                                        },
+                                    )}
+                                </Text>
+                            </Box>
+                        )}
+
                         <VStack
                             spacing={0}
                             w="full"
@@ -368,10 +463,13 @@ export const SendTokenSummaryContent = ({
                                     data-testid="send-summary-amount"
                                     color={textPrimary}
                                 >
-                                    {Number(amount).toLocaleString(undefined, {
-                                        minimumFractionDigits: 2,
-                                        maximumFractionDigits: 2,
-                                    })}{' '}
+                                    {Number(effectiveAmount).toLocaleString(
+                                        undefined,
+                                        {
+                                            minimumFractionDigits: 2,
+                                            maximumFractionDigits: 2,
+                                        },
+                                    )}{' '}
                                     {selectedToken.symbol}
                                 </Text>
                                 <Text color={textSecondary}>

--- a/packages/vechain-kit/src/components/common/GasFeeSummary.tsx
+++ b/packages/vechain-kit/src/components/common/GasFeeSummary.tsx
@@ -44,13 +44,20 @@ export const GasFeeSummary: React.FC<GasFeeSummaryProps> = ({
     userSelectedToken,
 }: GasFeeSummaryProps) => {
     const { t } = useTranslation();
-    const { feeDelegation } = useVeChainKitConfig();
+    const { feeDelegation, darkMode: isDark } = useVeChainKitConfig();
     const { connection, account } = useWallet();
     const { preferences, reorderTokenPriority } = useGasTokenSelection();
     const { isOpen, onOpen, onClose } = useDisclosure();
 
     const textPrimary = useToken('colors', 'vechain-kit-text-primary');
     const textSecondary = useToken('colors', 'vechain-kit-text-secondary');
+
+    // Subtle hover surface — lighten in dark mode, darken in light mode.
+    // Previously this used `textSecondary` as the hover bg, which matches
+    // the button's text color and made the label disappear on hover.
+    const hoverBg = isDark
+        ? 'rgba(255, 255, 255, 0.08)'
+        : 'rgba(0, 0, 0, 0.04)';
 
     const [tokenEstimations, setTokenEstimations] = useState<
         Record<GasTokenType, { cost: number; loading: boolean }>
@@ -281,7 +288,9 @@ export const GasFeeSummary: React.FC<GasFeeSummaryProps> = ({
                     color={textSecondary}
                     borderColor={textSecondary}
                     _hover={{
-                        bg: textSecondary,
+                        bg: hoverBg,
+                        color: textPrimary,
+                        borderColor: textPrimary,
                     }}
                     leftIcon={React.cloneElement(
                         TOKEN_LOGO_COMPONENTS[

--- a/packages/vechain-kit/src/components/common/GasFeeTokenSelector.tsx
+++ b/packages/vechain-kit/src/components/common/GasFeeTokenSelector.tsx
@@ -19,6 +19,7 @@ import { GasTokenType } from '@/types/gasToken';
 import { SUPPORTED_GAS_TOKENS, TOKEN_LOGO_COMPONENTS } from '@/utils/constants';
 import { formatGasCost } from '@/types/gasEstimation';
 import { useTokenBalances } from '@/hooks';
+import { useVeChainKitConfig } from '@/providers';
 import { BaseModal } from './BaseModal';
 
 interface GasFeeTokenSelectorProps {
@@ -41,6 +42,7 @@ export const GasFeeTokenSelector = ({
     walletAddress,
 }: GasFeeTokenSelectorProps) => {
     const { t } = useTranslation();
+    const { darkMode: isDark } = useVeChainKitConfig();
     const { balances } = useTokenBalances(walletAddress);
     const [tempSelectedToken, setTempSelectedToken] =
         React.useState(selectedToken);
@@ -50,6 +52,17 @@ export const GasFeeTokenSelector = ({
     const textSecondary = useToken('colors', 'vechain-kit-text-secondary');
     const textTertiary = useToken('colors', 'vechain-kit-text-tertiary');
     const errorColor = useToken('colors', 'vechain-kit-error');
+
+    // Subtle hover surface — lighten in dark mode, darken in light mode.
+    // Chakra's whiteAlpha/blackAlpha tokens aren't wired to the kit's
+    // custom darkMode flag (we don't use Chakra color mode), so we pick
+    // the alpha overlay manually.
+    const hoverBg = isDark
+        ? 'rgba(255, 255, 255, 0.08)'
+        : 'rgba(0, 0, 0, 0.04)';
+    const hoverBorder = isDark
+        ? 'rgba(255, 255, 255, 0.16)'
+        : 'rgba(0, 0, 0, 0.12)';
 
     const itemBg = (selected: boolean) =>
         selected ? textTertiary : 'transparent';
@@ -127,12 +140,14 @@ export const GasFeeTokenSelector = ({
                                 _hover={{
                                     backgroundColor: insufficient
                                         ? itemBg(isSelected)
-                                        : textSecondary
-                                        ? '#ffffff12'
-                                        : textSecondary,
+                                        : isSelected
+                                        ? itemBg(isSelected)
+                                        : hoverBg,
                                     borderColor: insufficient
                                         ? itemBorderColor(isSelected)
-                                        : textSecondary,
+                                        : isSelected
+                                        ? itemBorderColor(isSelected)
+                                        : hoverBorder,
                                 }}
                                 opacity={insufficient ? 0.5 : 1}
                                 onClick={() =>

--- a/packages/vechain-kit/src/components/common/GasFeeTokenSelector.tsx
+++ b/packages/vechain-kit/src/components/common/GasFeeTokenSelector.tsx
@@ -50,22 +50,28 @@ export const GasFeeTokenSelector = ({
 
     const textPrimary = useToken('colors', 'vechain-kit-text-primary');
     const textSecondary = useToken('colors', 'vechain-kit-text-secondary');
-    const textTertiary = useToken('colors', 'vechain-kit-text-tertiary');
     const errorColor = useToken('colors', 'vechain-kit-error');
 
-    // Subtle hover surface — lighten in dark mode, darken in light mode.
+    // Hover / selected surfaces — alpha overlays on the modal bg.
     // Chakra's whiteAlpha/blackAlpha tokens aren't wired to the kit's
     // custom darkMode flag (we don't use Chakra color mode), so we pick
-    // the alpha overlay manually.
+    // the alpha overlay manually. Selected sits a notch above hover so
+    // the active row reads as picked without yelling — previously this
+    // row used `textTertiary` (a text colour: a near-white at 50% in
+    // dark mode, mid-grey #718096 in light mode), which was way too
+    // strong as a background.
     const hoverBg = isDark
         ? 'rgba(255, 255, 255, 0.08)'
         : 'rgba(0, 0, 0, 0.04)';
     const hoverBorder = isDark
         ? 'rgba(255, 255, 255, 0.16)'
         : 'rgba(0, 0, 0, 0.12)';
+    const selectedBg = isDark
+        ? 'rgba(255, 255, 255, 0.12)'
+        : 'rgba(0, 0, 0, 0.06)';
 
     const itemBg = (selected: boolean) =>
-        selected ? textTertiary : 'transparent';
+        selected ? selectedBg : 'transparent';
     const itemBorderColor = (selected: boolean) =>
         selected ? textPrimary : 'transparent';
 

--- a/packages/vechain-kit/src/constants/urls.ts
+++ b/packages/vechain-kit/src/constants/urls.ts
@@ -34,6 +34,15 @@ export const GENERIC_DELEGATOR_MAINNET_URL =
 export const GENERIC_DELEGATOR_TESTNET_URL =
     'https://testnet.delegator.vechain.org';
 
+// VeChain-sponsored fee delegator used to subsidize kit-managed onboarding
+// actions (claim a domain, update profile records) so users without any
+// gas tokens can still complete first-time setup. The user signs as usual;
+// VeChain pays the gas. Each URL is a vechain.energy sponsor endpoint.
+export const KIT_SPONSORED_DELEGATOR_MAINNET_URL =
+    'https://sponsor.vechain.energy/by/1060';
+export const KIT_SPONSORED_DELEGATOR_TESTNET_URL =
+    'https://sponsor-testnet.vechain.energy/by/221';
+
 // Explorers
 export const VECHAIN_EXPLORER_BASE_URL = 'https://explore.vechain.org';
 export const VECHAIN_EXPLORER_TESTNET_BASE_URL =

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useClaimVeWorldSubdomain.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useClaimVeWorldSubdomain.ts
@@ -11,7 +11,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { getConfig } from '@/config';
 import { useVeChainKitConfig, VeChainKitConfig } from '@/providers';
-import { humanAddress } from '@/utils';
+import { getKitSponsoredDelegatorUrl, humanAddress } from '@/utils';
 import { ethers } from 'ethers';
 import { useRefreshMetadata } from '../wallet/useRefreshMetadata';
 import { invalidateAndRefetchDomainQueries } from './utils/domainQueryUtils';
@@ -199,7 +199,12 @@ export const useClaimVeWorldSubdomain = ({
         ...result,
         clauses,
         sendTransaction: async () => {
-            return result.sendTransaction(clauses());
+            // Route through VeChain's sponsored delegator so new users
+            // without VTHO / B3TR can still claim a veworld.vet subdomain.
+            return result.sendTransaction(
+                clauses(),
+                getKitSponsoredDelegatorUrl(),
+            );
         },
     };
 };

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useClaimVetDomain.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useClaimVetDomain.ts
@@ -11,7 +11,7 @@ import { getConfig } from '@/config';
 import { useVeChainKitConfig, VeChainKitConfig } from '@/providers';
 import { ethers } from 'ethers';
 import { invalidateAndRefetchDomainQueries } from './utils/domainQueryUtils';
-import { humanAddress } from '@/utils';
+import { getKitSponsoredDelegatorUrl, humanAddress } from '@/utils';
 import { Wallet } from '@/types';
 import { TransactionClause } from '@vechain/sdk-core';
 
@@ -147,7 +147,12 @@ export const useClaimVetDomain = ({
         ...result,
         clauses,
         sendTransaction: async () => {
-            return result.sendTransaction(clauses());
+            // Route through VeChain's sponsored delegator so new users without
+            // VTHO / B3TR can still claim a domain.
+            return result.sendTransaction(
+                clauses(),
+                getKitSponsoredDelegatorUrl(),
+            );
         },
     };
 };

--- a/packages/vechain-kit/src/hooks/api/vetDomains/useUpdateTextRecord.ts
+++ b/packages/vechain-kit/src/hooks/api/vetDomains/useUpdateTextRecord.ts
@@ -2,6 +2,7 @@ import { Interface, namehash } from 'ethers';
 import { useCallback } from 'react';
 import { UseSendTransactionReturnValue, useSendTransaction } from '@/hooks';
 import { TransactionClause } from '@vechain/sdk-core';
+import { getKitSponsoredDelegatorUrl } from '@/utils';
 
 const nameInterface = new Interface([
     'function resolver(bytes32 node) returns (address resolverAddress)',
@@ -87,7 +88,12 @@ export const useUpdateTextRecord = ({
         ...result,
         clauses: buildClausesCallback, // Return the callback directly
         sendTransaction: async (params: UpdateTextRecordVariables[]) => {
-            return result.sendTransaction(buildClausesCallback(params));
+            // Route through VeChain's sponsored delegator so users without
+            // VTHO / B3TR can still update their profile records.
+            return result.sendTransaction(
+                buildClausesCallback(params),
+                getKitSponsoredDelegatorUrl(),
+            );
         },
     };
 };

--- a/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
@@ -1,8 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { GasTokenType } from '@/types';
-import { useSmartAccount, useWallet, estimateGas } from '@/hooks';
+import {
+    useSmartAccount,
+    useWallet,
+    estimateGas,
+    useGetAccountVersion,
+    computeCorrectedTotalGasNoFeePayer,
+    convertGasToGasTokenAmount,
+} from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
+import { ThorClient } from '@vechain/sdk-network';
+import { getConfig } from '@/config';
 
 export interface UseEstimateAllTokensParams {
     clauses: TransactionClause[];
@@ -19,7 +28,12 @@ export const useEstimateAllTokens = ({
     const { data: smartAccount } = useSmartAccount(
         connectedWallet?.address ?? '',
     );
-    const { feeDelegation } = useVeChainKitConfig();
+    const { data: smartAccountVersion } = useGetAccountVersion(
+        smartAccount?.address ?? '',
+        connectedWallet?.address ?? '',
+    );
+    const { feeDelegation, network } = useVeChainKitConfig();
+    const thor = ThorClient.at(getConfig(network.type).nodeUrl);
 
     return useQuery({
         queryKey: [
@@ -33,6 +47,15 @@ export const useEstimateAllTokens = ({
                 { cost: number; loading: boolean; error?: string }
             > = {} as any;
 
+            // Local gas estimate is token-agnostic — compute once,
+            // bounded by a timeout so a slow node can't hang the UI.
+            const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
+                thor,
+                clauses,
+                smartAccountAddress: smartAccount?.address ?? '',
+                version: smartAccountVersion?.version ?? 0,
+            });
+
             await Promise.all(
                 tokens.map(async (token) => {
                     try {
@@ -43,8 +66,16 @@ export const useEstimateAllTokens = ({
                             token,
                             'medium',
                         );
+                        const correctedCost =
+                            totalGasNoFeePayer !== null
+                                ? convertGasToGasTokenAmount({
+                                      totalGasNoFeePayer,
+                                      gasToken: token,
+                                      estimationResponse: estimation,
+                                  })
+                                : (estimation.transactionCost ?? 0) * 2;
                         estimates[token] = {
-                            cost: estimation.transactionCost || 0,
+                            cost: correctedCost || 0,
                             loading: false,
                         };
                     } catch (error) {

--- a/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
@@ -21,6 +21,16 @@ export const useEstimateAllTokens = ({
     );
     const { feeDelegation } = useVeChainKitConfig();
 
+    // eslint-disable-next-line no-console
+    console.log('[vk-debug] useEstimateAllTokens inputs:', {
+        callerEnabled: enabled,
+        clausesLen: clauses.length,
+        smartAccountAddress: smartAccount?.address,
+        genericDelegatorUrl: feeDelegation?.genericDelegatorUrl,
+        delegatorUrl: feeDelegation?.delegatorUrl,
+        tokensLen: tokens.length,
+    });
+
     return useQuery({
         queryKey: [
             'gas-estimation-all-tokens',

--- a/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
@@ -5,7 +5,8 @@ import {
     useWallet,
     estimateGas,
     useGetAccountVersion,
-    computeCorrectedGasTokenCost,
+    computeCorrectedTotalGasNoFeePayer,
+    convertGasToGasTokenAmount,
 } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
@@ -46,6 +47,15 @@ export const useEstimateAllTokens = ({
                 { cost: number; loading: boolean; error?: string }
             > = {} as any;
 
+            // Local gas estimate is token-agnostic — compute once,
+            // bounded by a timeout so a slow node can't hang the UI.
+            const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
+                thor,
+                clauses,
+                smartAccountAddress: smartAccount?.address ?? '',
+                version: smartAccountVersion?.version ?? 0,
+            });
+
             await Promise.all(
                 tokens.map(async (token) => {
                     try {
@@ -56,14 +66,14 @@ export const useEstimateAllTokens = ({
                             token,
                             'medium',
                         );
-                        const correctedCost = await computeCorrectedGasTokenCost({
-                            thor,
-                            clauses,
-                            smartAccountAddress: smartAccount?.address ?? '',
-                            version: smartAccountVersion?.version ?? 0,
-                            estimationResponse: estimation,
-                            gasToken: token,
-                        });
+                        const correctedCost =
+                            totalGasNoFeePayer !== null
+                                ? convertGasToGasTokenAmount({
+                                      totalGasNoFeePayer,
+                                      gasToken: token,
+                                      estimationResponse: estimation,
+                                  })
+                                : (estimation.transactionCost ?? 0) * 2;
                         estimates[token] = {
                             cost: correctedCost || 0,
                             loading: false,

--- a/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
@@ -1,8 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { GasTokenType } from '@/types';
-import { useSmartAccount, useWallet, estimateGas } from '@/hooks';
+import {
+    useSmartAccount,
+    useWallet,
+    estimateGas,
+    useGetAccountVersion,
+    computeCorrectedGasTokenCost,
+} from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
+import { ThorClient } from '@vechain/sdk-network';
+import { getConfig } from '@/config';
 
 export interface UseEstimateAllTokensParams {
     clauses: TransactionClause[];
@@ -19,7 +27,12 @@ export const useEstimateAllTokens = ({
     const { data: smartAccount } = useSmartAccount(
         connectedWallet?.address ?? '',
     );
-    const { feeDelegation } = useVeChainKitConfig();
+    const { data: smartAccountVersion } = useGetAccountVersion(
+        smartAccount?.address ?? '',
+        connectedWallet?.address ?? '',
+    );
+    const { feeDelegation, network } = useVeChainKitConfig();
+    const thor = ThorClient.at(getConfig(network.type).nodeUrl);
 
     return useQuery({
         queryKey: [
@@ -43,8 +56,16 @@ export const useEstimateAllTokens = ({
                             token,
                             'medium',
                         );
+                        const correctedCost = await computeCorrectedGasTokenCost({
+                            thor,
+                            clauses,
+                            smartAccountAddress: smartAccount?.address ?? '',
+                            version: smartAccountVersion?.version ?? 0,
+                            estimationResponse: estimation,
+                            gasToken: token,
+                        });
                         estimates[token] = {
-                            cost: estimation.transactionCost || 0,
+                            cost: correctedCost || 0,
                             loading: false,
                         };
                     } catch (error) {

--- a/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
@@ -21,16 +21,6 @@ export const useEstimateAllTokens = ({
     );
     const { feeDelegation } = useVeChainKitConfig();
 
-    // eslint-disable-next-line no-console
-    console.log('[vk-debug] useEstimateAllTokens inputs:', {
-        callerEnabled: enabled,
-        clausesLen: clauses.length,
-        smartAccountAddress: smartAccount?.address,
-        genericDelegatorUrl: feeDelegation?.genericDelegatorUrl,
-        delegatorUrl: feeDelegation?.delegatorUrl,
-        tokensLen: tokens.length,
-    });
-
     return useQuery({
         queryKey: [
             'gas-estimation-all-tokens',

--- a/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useEstimateAllTokens.ts
@@ -1,17 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { GasTokenType } from '@/types';
-import {
-    useSmartAccount,
-    useWallet,
-    estimateGas,
-    useGetAccountVersion,
-    computeCorrectedTotalGasNoFeePayer,
-    convertGasToGasTokenAmount,
-} from '@/hooks';
+import { useSmartAccount, useWallet, estimateGas } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
-import { ThorClient } from '@vechain/sdk-network';
-import { getConfig } from '@/config';
 
 export interface UseEstimateAllTokensParams {
     clauses: TransactionClause[];
@@ -28,12 +19,7 @@ export const useEstimateAllTokens = ({
     const { data: smartAccount } = useSmartAccount(
         connectedWallet?.address ?? '',
     );
-    const { data: smartAccountVersion } = useGetAccountVersion(
-        smartAccount?.address ?? '',
-        connectedWallet?.address ?? '',
-    );
-    const { feeDelegation, network } = useVeChainKitConfig();
-    const thor = ThorClient.at(getConfig(network.type).nodeUrl);
+    const { feeDelegation } = useVeChainKitConfig();
 
     return useQuery({
         queryKey: [
@@ -47,15 +33,6 @@ export const useEstimateAllTokens = ({
                 { cost: number; loading: boolean; error?: string }
             > = {} as any;
 
-            // Local gas estimate is token-agnostic — compute once,
-            // bounded by a timeout so a slow node can't hang the UI.
-            const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
-                thor,
-                clauses,
-                smartAccountAddress: smartAccount?.address ?? '',
-                version: smartAccountVersion?.version ?? 0,
-            });
-
             await Promise.all(
                 tokens.map(async (token) => {
                     try {
@@ -66,16 +43,8 @@ export const useEstimateAllTokens = ({
                             token,
                             'medium',
                         );
-                        const correctedCost =
-                            totalGasNoFeePayer !== null
-                                ? convertGasToGasTokenAmount({
-                                      totalGasNoFeePayer,
-                                      gasToken: token,
-                                      estimationResponse: estimation,
-                                  })
-                                : (estimation.transactionCost ?? 0) * 2;
                         estimates[token] = {
-                            cost: correctedCost || 0,
+                            cost: estimation.transactionCost || 0,
                             loading: false,
                         };
                     } catch (error) {

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts
@@ -134,69 +134,87 @@ export const estimateAndBuildTxBody = async (
 };
 
 /**
- * Compute the gas-token amount the smart account must transfer to the
- * generic delegator's deposit account to cover the transaction.
- *
- * The delegator's `/estimate/clauses` endpoint simulates the user's raw
- * clauses as if executed directly by the smart account, with no
- * `executeWithAuthorization` wrapper and no embedded-wallet signature, so
- * it under-estimates (and for NFT-heavy clauses can revert outright). We
- * trust its **rate** information (the gas-token-per-gas ratio is just a
- * market price and doesn't depend on the gas amount) but recompute the
- * gas number locally — including the wrapper overhead, fee-payer overhead,
- * and a 10% safety multiplier — and reapply the rate.
- *
- * @param thor - Thor client used for the local gas estimation
- * @param clauses - The user's raw clauses (NOT the wrapped ones)
- * @param smartAccountAddress - Caller used during simulation
- * @param version - Smart account version (selects the wrapper overhead)
- * @param estimationResponse - The delegator's /estimate/clauses response
- * @param gasToken - The selected gas token (selects the fee-payer overhead)
- * @returns The corrected gas-token amount as a decimal (human-readable)
+ * Hard timeout (ms) applied to the local Thor gas estimation. Stops the
+ * fee-estimation UI from hanging if the node is slow or unreachable.
  */
-export const computeCorrectedGasTokenCost = async ({
+export const GENERIC_DELEGATOR_LOCAL_ESTIMATE_TIMEOUT_MS = 6_000;
+
+const withTimeout = <T>(
+    promise: Promise<T>,
+    ms: number,
+): Promise<T | null> =>
+    new Promise<T | null>((resolve) => {
+        const timer = setTimeout(() => resolve(null), ms);
+        promise
+            .then((value) => {
+                clearTimeout(timer);
+                resolve(value);
+            })
+            .catch(() => {
+                clearTimeout(timer);
+                resolve(null);
+            });
+    });
+
+/**
+ * Run the local Thor gas estimation for the user's raw clauses (caller =
+ * smart account) and return the gas-token-agnostic total: raw gas + wrapper
+ * overhead, padded by the safety multiplier. Returns `null` if the
+ * simulation reverts, times out, or returns a non-positive number — the
+ * caller should then fall back to a delegator-derived estimate.
+ *
+ * The output is independent of the gas token, so callers iterating over
+ * a token-priority list should call this once and reuse the result.
+ */
+export const computeCorrectedTotalGasNoFeePayer = async ({
     thor,
     clauses,
     smartAccountAddress,
     version,
-    estimationResponse,
-    gasToken,
+    timeoutMs = GENERIC_DELEGATOR_LOCAL_ESTIMATE_TIMEOUT_MS,
 }: {
     thor: ThorClient;
     clauses: TransactionClause[];
     smartAccountAddress: string;
     version: number;
-    estimationResponse: EstimationResponse;
-    gasToken: GasTokenType;
-}): Promise<number> => {
-    const fallbackCost = (estimationResponse.transactionCost ?? 0) * 2;
+    timeoutMs?: number;
+}): Promise<number | null> => {
+    const rawGasResult = await withTimeout(
+        thor.gas.estimateGas(clauses, smartAccountAddress),
+        timeoutMs,
+    );
 
-    let rawGas: number;
-    try {
-        const rawGasResult = await thor.gas.estimateGas(
-            clauses,
-            smartAccountAddress,
-        );
-        rawGas = rawGasResult.totalGas;
-    } catch {
-        return fallbackCost;
-    }
-
+    const rawGas = rawGasResult?.totalGas;
     if (!rawGas || rawGas <= 0) {
-        return fallbackCost;
+        return null;
     }
 
     const wrapperOverhead = getWrapperOverheadGas(version);
-    const feePayerOverhead = GENERIC_DELEGATOR_FEE_PAYER_OVERHEAD_GAS[gasToken];
-
-    const totalGas = Math.ceil(
-        (rawGas + wrapperOverhead) * GENERIC_DELEGATOR_GAS_SAFETY_MULTIPLIER +
-            feePayerOverhead,
+    return Math.ceil(
+        (rawGas + wrapperOverhead) * GENERIC_DELEGATOR_GAS_SAFETY_MULTIPLIER,
     );
+};
 
-    // Derive the gas-token-per-gas rate from the delegator response. The
-    // rate is price-driven and independent of the gas amount, so it
-    // remains accurate even when the delegator's gas number is wrong.
+/**
+ * Convert a gas number (without the fee-payer transfer overhead) into the
+ * gas-token amount required to cover the transaction, using the per-gas
+ * rate returned by the delegator's `/estimate/clauses` response (which is
+ * accurate even when the absolute gas number from the same response is
+ * not). Adds the gas-token-specific fee-payer transfer overhead.
+ */
+export const convertGasToGasTokenAmount = ({
+    totalGasNoFeePayer,
+    gasToken,
+    estimationResponse,
+}: {
+    totalGasNoFeePayer: number;
+    gasToken: GasTokenType;
+    estimationResponse: EstimationResponse;
+}): number => {
+    const totalGas =
+        totalGasNoFeePayer +
+        GENERIC_DELEGATOR_FEE_PAYER_OVERHEAD_GAS[gasToken];
+
     let gasTokenPerGas = 0;
     if (
         estimationResponse.transactionCost &&
@@ -210,16 +228,65 @@ export const computeCorrectedGasTokenCost = async ({
         const rate = estimationResponse.rate ?? 1;
         const serviceFee = estimationResponse.serviceFee ?? 0;
         gasTokenPerGas =
-            estimationResponse.vthoPerGasAtSpeed *
-            rate *
-            (1 + serviceFee);
+            estimationResponse.vthoPerGasAtSpeed * rate * (1 + serviceFee);
     }
 
     if (!gasTokenPerGas || gasTokenPerGas <= 0) {
-        return fallbackCost;
+        return 0;
     }
 
     return totalGas * gasTokenPerGas;
+};
+
+/**
+ * Compute the gas-token amount the smart account must transfer to the
+ * generic delegator's deposit account to cover the transaction.
+ *
+ * The delegator's `/estimate/clauses` endpoint simulates the user's raw
+ * clauses as if executed directly by the smart account, with no
+ * `executeWithAuthorization` wrapper and no embedded-wallet signature, so
+ * it under-estimates (and for NFT-heavy clauses can revert outright). We
+ * trust its **rate** information (the gas-token-per-gas ratio is just a
+ * market price and doesn't depend on the gas amount) but recompute the
+ * gas number locally — including the wrapper overhead, fee-payer overhead,
+ * and a 10% safety multiplier — and reapply the rate.
+ */
+export const computeCorrectedGasTokenCost = async ({
+    thor,
+    clauses,
+    smartAccountAddress,
+    version,
+    estimationResponse,
+    gasToken,
+    timeoutMs,
+}: {
+    thor: ThorClient;
+    clauses: TransactionClause[];
+    smartAccountAddress: string;
+    version: number;
+    estimationResponse: EstimationResponse;
+    gasToken: GasTokenType;
+    timeoutMs?: number;
+}): Promise<number> => {
+    const fallbackCost = (estimationResponse.transactionCost ?? 0) * 2;
+
+    const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
+        thor,
+        clauses,
+        smartAccountAddress,
+        version,
+        timeoutMs,
+    });
+    if (totalGasNoFeePayer === null) {
+        return fallbackCost;
+    }
+
+    const cost = convertGasToGasTokenAmount({
+        totalGasNoFeePayer,
+        gasToken,
+        estimationResponse,
+    });
+    return cost > 0 ? cost : fallbackCost;
 };
 
 /**

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts
@@ -14,6 +14,39 @@ import { getConfig } from '@/config';
 import { useVeChainKitConfig } from '@/providers';
 import { useCallback } from 'react';
 
+/**
+ * Safety multiplier applied on top of the locally-estimated gas to absorb
+ * variance between simulation and on-chain execution. Mirrors VeWorld
+ * mobile's heuristic.
+ */
+export const GENERIC_DELEGATOR_GAS_SAFETY_MULTIPLIER = 1.1;
+
+/**
+ * Fixed gas cost for the extra transfer clause that pays the generic
+ * delegator's deposit account. VET transfers are bare value transfers
+ * (~21k), ERC-20 transfers (VTHO, B3TR) are ~50-55k depending on the
+ * recipient cold/warm state.
+ */
+export const GENERIC_DELEGATOR_FEE_PAYER_OVERHEAD_GAS: Record<GasTokenType, number> = {
+    VET: 21_000,
+    VTHO: 55_000,
+    B3TR: 55_000,
+};
+
+/**
+ * Gas overhead added on top of the raw user-clause estimate to account for
+ * the smart-account `executeWithAuthorization` / `executeBatchWithAuthorization`
+ * wrapper (signature verification, calldata decoding, per-clause dispatch).
+ */
+export const GENERIC_DELEGATOR_WRAPPER_OVERHEAD_GAS: Record<number, number> = {
+    1: 80_000,
+    3: 120_000,
+};
+
+const getWrapperOverheadGas = (version: number): number =>
+    GENERIC_DELEGATOR_WRAPPER_OVERHEAD_GAS[version] ??
+    GENERIC_DELEGATOR_WRAPPER_OVERHEAD_GAS[3];
+
 export const estimateGas = async (
     signerAddress: string,
     genericDelegatorUrl: string,
@@ -101,6 +134,95 @@ export const estimateAndBuildTxBody = async (
 };
 
 /**
+ * Compute the gas-token amount the smart account must transfer to the
+ * generic delegator's deposit account to cover the transaction.
+ *
+ * The delegator's `/estimate/clauses` endpoint simulates the user's raw
+ * clauses as if executed directly by the smart account, with no
+ * `executeWithAuthorization` wrapper and no embedded-wallet signature, so
+ * it under-estimates (and for NFT-heavy clauses can revert outright). We
+ * trust its **rate** information (the gas-token-per-gas ratio is just a
+ * market price and doesn't depend on the gas amount) but recompute the
+ * gas number locally — including the wrapper overhead, fee-payer overhead,
+ * and a 10% safety multiplier — and reapply the rate.
+ *
+ * @param thor - Thor client used for the local gas estimation
+ * @param clauses - The user's raw clauses (NOT the wrapped ones)
+ * @param smartAccountAddress - Caller used during simulation
+ * @param version - Smart account version (selects the wrapper overhead)
+ * @param estimationResponse - The delegator's /estimate/clauses response
+ * @param gasToken - The selected gas token (selects the fee-payer overhead)
+ * @returns The corrected gas-token amount as a decimal (human-readable)
+ */
+export const computeCorrectedGasTokenCost = async ({
+    thor,
+    clauses,
+    smartAccountAddress,
+    version,
+    estimationResponse,
+    gasToken,
+}: {
+    thor: ThorClient;
+    clauses: TransactionClause[];
+    smartAccountAddress: string;
+    version: number;
+    estimationResponse: EstimationResponse;
+    gasToken: GasTokenType;
+}): Promise<number> => {
+    const fallbackCost = (estimationResponse.transactionCost ?? 0) * 2;
+
+    let rawGas: number;
+    try {
+        const rawGasResult = await thor.gas.estimateGas(
+            clauses,
+            smartAccountAddress,
+        );
+        rawGas = rawGasResult.totalGas;
+    } catch {
+        return fallbackCost;
+    }
+
+    if (!rawGas || rawGas <= 0) {
+        return fallbackCost;
+    }
+
+    const wrapperOverhead = getWrapperOverheadGas(version);
+    const feePayerOverhead = GENERIC_DELEGATOR_FEE_PAYER_OVERHEAD_GAS[gasToken];
+
+    const totalGas = Math.ceil(
+        (rawGas + wrapperOverhead) * GENERIC_DELEGATOR_GAS_SAFETY_MULTIPLIER +
+            feePayerOverhead,
+    );
+
+    // Derive the gas-token-per-gas rate from the delegator response. The
+    // rate is price-driven and independent of the gas amount, so it
+    // remains accurate even when the delegator's gas number is wrong.
+    let gasTokenPerGas = 0;
+    if (
+        estimationResponse.transactionCost &&
+        estimationResponse.estimatedGas &&
+        estimationResponse.estimatedGas > 0
+    ) {
+        gasTokenPerGas =
+            estimationResponse.transactionCost /
+            estimationResponse.estimatedGas;
+    } else if (estimationResponse.vthoPerGasAtSpeed) {
+        const rate = estimationResponse.rate ?? 1;
+        const serviceFee = estimationResponse.serviceFee ?? 0;
+        gasTokenPerGas =
+            estimationResponse.vthoPerGasAtSpeed *
+            rate *
+            (1 + serviceFee);
+    }
+
+    if (!gasTokenPerGas || gasTokenPerGas <= 0) {
+        return fallbackCost;
+    }
+
+    return totalGas * gasTokenPerGas;
+};
+
+/**
  * Sign the final transaction with the given private key and signature
  * returned by the generic delegator.
  * @param decodedTx The decoded transaction returned by the generic delegator.
@@ -155,18 +277,41 @@ export const useGenericDelegator = () => {
     }): Promise<string> => {
         try {
             const gasToken = preferences.gasTokenToUse;
-            const gasEstimationResponse: EstimationResponse = await estimateGas(smartAccount?.address ?? '', genericDelegatorUrl, clauses as TransactionClause[], gasToken, 'medium');
+            const gasEstimationResponse: EstimationResponse = await estimateGas(
+                smartAccount?.address ?? '',
+                genericDelegatorUrl,
+                clauses as TransactionClause[],
+                gasToken,
+                'medium',
+            );
 
             const depositAccount: DepositAccount = await getDepositAccount(genericDelegatorUrl);
 
+            const correctedTransactionCost = await computeCorrectedGasTokenCost({
+                thor,
+                clauses,
+                smartAccountAddress: smartAccount?.address ?? '',
+                version: smartAccountVersion?.version ?? 0,
+                estimationResponse: gasEstimationResponse,
+                gasToken,
+            });
+
+            const transferAmountWei = parseEther(
+                correctedTransactionCost.toString(),
+            ).toString();
+
             const transferToGenericDelegatorClause = {
-                to: gasToken === 'VET' ? depositAccount.depositAccount : SUPPORTED_GAS_TOKENS[gasToken as GasTokenType].address,
-                value: gasToken === 'VET' ? parseEther(gasEstimationResponse.transactionCost?.toString() ?? '0').toString() : '0x0',
-                data: gasToken === 'VET' ? '0x' : ERC20Interface.encodeFunctionData('transfer', [
-                    depositAccount.depositAccount,
-                    parseEther(gasEstimationResponse.transactionCost?.toString() ?? '0'),
-                ]),
-                comment: `Transfer ${gasEstimationResponse.transactionCost} ${gasToken} to ${depositAccount.depositAccount}`,
+                to: gasToken === 'VET'
+                    ? depositAccount.depositAccount
+                    : SUPPORTED_GAS_TOKENS[gasToken as GasTokenType].address,
+                value: gasToken === 'VET' ? transferAmountWei : '0x0',
+                data: gasToken === 'VET'
+                    ? '0x'
+                    : ERC20Interface.encodeFunctionData('transfer', [
+                          depositAccount.depositAccount,
+                          transferAmountWei,
+                      ]),
+                comment: `Transfer ${correctedTransactionCost} ${gasToken} to ${depositAccount.depositAccount}`,
                 abi: gasToken === 'VET' ? undefined : ERC20Interface.getFunction('transfer'),
             };
 

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
@@ -1,20 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { EstimationResponse } from '@/types/gasEstimation';
 import { EnhancedClause, GasTokenType } from '@/types';
-import {
-    useSmartAccount,
-    useWallet,
-    estimateGas,
-    useTokenBalances,
-    useGasTokenSelection,
-    useGetAccountVersion,
-    computeCorrectedTotalGasNoFeePayer,
-    convertGasToGasTokenAmount,
-} from '@/hooks';
+import { useSmartAccount, useWallet, estimateGas, useTokenBalances, useGasTokenSelection } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
-import { ThorClient } from '@vechain/sdk-network';
-import { getConfig } from '@/config';
 
 export interface useGenericDelegatorFeeEstimationParams {
     clauses: EnhancedClause[];
@@ -35,32 +24,15 @@ export const useGenericDelegatorFeeEstimation = ({
     const { data: smartAccount } = useSmartAccount(
         connectedWallet?.address ?? '',
     );
-    const { data: smartAccountVersion } = useGetAccountVersion(
-        smartAccount?.address ?? '',
-        connectedWallet?.address ?? '',
-    );
-    const { feeDelegation, network } = useVeChainKitConfig();
+    const { feeDelegation } = useVeChainKitConfig();
     const { balances } = useTokenBalances(account?.address ?? '');
     const { updatePreferences } = useGasTokenSelection();
-    const thor = ThorClient.at(getConfig(network.type).nodeUrl);
     // Only include essential data in query key to prevent unnecessary refetches
     const queryKey = ['gas-estimation', JSON.stringify(clauses), JSON.stringify(tokens), sendingAmount, sendingTokenSymbol];
-
+    
     return useQuery<EstimationResponse & { usedToken: string }, Error>({
         queryKey,
         queryFn: async () => {
-            // Run the local Thor gas estimate ONCE — the gas number is
-            // token-agnostic so we shouldn't pay for it inside the loop.
-            // Bounded by a timeout so a slow / unreachable node can't
-            // hang the fee-estimation UI forever; on timeout/failure each
-            // token falls back to a delegator-derived value.
-            const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
-                thor,
-                clauses: clauses as TransactionClause[],
-                smartAccountAddress: smartAccount?.address ?? '',
-                version: smartAccountVersion?.version ?? 0,
-            });
-
             let lastError: Error | null = null;
             // Try each token in sequence until one succeeds AND has sufficient balance
             for (const token of tokens) {
@@ -72,31 +44,20 @@ export const useGenericDelegatorFeeEstimation = ({
                         token as GasTokenType,
                         'medium',
                     );
-                    // The delegator's `transactionCost` is computed from a
-                    // simulation that omits the smart-account auth wrapper
-                    // and can underestimate (or revert outright). Reapply the
-                    // delegator's per-gas rate to our locally-estimated gas
-                    // number so the UI agrees with the actual send path.
-                    const gasCost =
-                        totalGasNoFeePayer !== null
-                            ? convertGasToGasTokenAmount({
-                                  totalGasNoFeePayer,
-                                  gasToken: token as GasTokenType,
-                                  estimationResponse: estimation,
-                              })
-                            : (estimation.transactionCost ?? 0) * 2;
+                    // Check if user has enough balance for this token
+                    const gasCost = estimation.transactionCost;
                     const tokenBalance = Number(balances.find(t => t.symbol === token)?.balance || 0);
                     // If sending the same token as gas token, need balance for both
                     // If no sendingAmount is provided, we're only checking for gas fees
-                    const additionalAmount = (sendingAmount && sendingTokenSymbol && token === sendingTokenSymbol)
+                    const additionalAmount = (sendingAmount && sendingTokenSymbol && token === sendingTokenSymbol) 
                         ? Number(sendingAmount)
                         : 0;
                     const requiredBalance = gasCost + additionalAmount;
-
+                    
                     if (tokenBalance >= requiredBalance) {
                         // Has enough balance, return this token
                         updatePreferences({ gasTokenToUse: token as GasTokenType });
-                        return { ...estimation, transactionCost: gasCost, usedToken: token };
+                        return { ...estimation, usedToken: token };
                     }
                     // Not enough balance, try next token
                     lastError = new Error(`Insufficient ${token} balance: has ${tokenBalance}, needs ${requiredBalance}`);

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
@@ -30,18 +30,6 @@ export const useGenericDelegatorFeeEstimation = ({
     // Only include essential data in query key to prevent unnecessary refetches
     const queryKey = ['gas-estimation', JSON.stringify(clauses), JSON.stringify(tokens), sendingAmount, sendingTokenSymbol];
 
-    // eslint-disable-next-line no-console
-    console.log('[vk-debug] useGenericDelegatorFeeEstimation inputs:', {
-        callerEnabled: enabled,
-        clausesLen: clauses.length,
-        accountAddress: account?.address,
-        smartAccountAddress: smartAccount?.address,
-        genericDelegatorUrl: feeDelegation?.genericDelegatorUrl,
-        delegatorUrl: feeDelegation?.delegatorUrl,
-        tokensLen: tokens.length,
-        balancesLen: balances.length,
-    });
-
     return useQuery<EstimationResponse & { usedToken: string }, Error>({
         queryKey,
         queryFn: async () => {

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
@@ -29,7 +29,19 @@ export const useGenericDelegatorFeeEstimation = ({
     const { updatePreferences } = useGasTokenSelection();
     // Only include essential data in query key to prevent unnecessary refetches
     const queryKey = ['gas-estimation', JSON.stringify(clauses), JSON.stringify(tokens), sendingAmount, sendingTokenSymbol];
-    
+
+    // eslint-disable-next-line no-console
+    console.log('[vk-debug] useGenericDelegatorFeeEstimation inputs:', {
+        callerEnabled: enabled,
+        clausesLen: clauses.length,
+        accountAddress: account?.address,
+        smartAccountAddress: smartAccount?.address,
+        genericDelegatorUrl: feeDelegation?.genericDelegatorUrl,
+        delegatorUrl: feeDelegation?.delegatorUrl,
+        tokensLen: tokens.length,
+        balancesLen: balances.length,
+    });
+
     return useQuery<EstimationResponse & { usedToken: string }, Error>({
         queryKey,
         queryFn: async () => {

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
@@ -1,9 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { EstimationResponse } from '@/types/gasEstimation';
 import { EnhancedClause, GasTokenType } from '@/types';
-import { useSmartAccount, useWallet, estimateGas, useTokenBalances, useGasTokenSelection } from '@/hooks';
+import {
+    useSmartAccount,
+    useWallet,
+    estimateGas,
+    useTokenBalances,
+    useGasTokenSelection,
+    useGetAccountVersion,
+    computeCorrectedGasTokenCost,
+} from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
+import { ThorClient } from '@vechain/sdk-network';
+import { getConfig } from '@/config';
 
 export interface useGenericDelegatorFeeEstimationParams {
     clauses: EnhancedClause[];
@@ -24,12 +34,17 @@ export const useGenericDelegatorFeeEstimation = ({
     const { data: smartAccount } = useSmartAccount(
         connectedWallet?.address ?? '',
     );
-    const { feeDelegation } = useVeChainKitConfig();
+    const { data: smartAccountVersion } = useGetAccountVersion(
+        smartAccount?.address ?? '',
+        connectedWallet?.address ?? '',
+    );
+    const { feeDelegation, network } = useVeChainKitConfig();
     const { balances } = useTokenBalances(account?.address ?? '');
     const { updatePreferences } = useGasTokenSelection();
+    const thor = ThorClient.at(getConfig(network.type).nodeUrl);
     // Only include essential data in query key to prevent unnecessary refetches
     const queryKey = ['gas-estimation', JSON.stringify(clauses), JSON.stringify(tokens), sendingAmount, sendingTokenSymbol];
-    
+
     return useQuery<EstimationResponse & { usedToken: string }, Error>({
         queryKey,
         queryFn: async () => {
@@ -44,20 +59,30 @@ export const useGenericDelegatorFeeEstimation = ({
                         token as GasTokenType,
                         'medium',
                     );
-                    // Check if user has enough balance for this token
-                    const gasCost = estimation.transactionCost;
+                    // The delegator's `transactionCost` is computed from a
+                    // simulation that omits the smart-account auth wrapper
+                    // and can underestimate (or revert outright). Recompute
+                    // locally so the UI agrees with the actual send path.
+                    const gasCost = await computeCorrectedGasTokenCost({
+                        thor,
+                        clauses: clauses as TransactionClause[],
+                        smartAccountAddress: smartAccount?.address ?? '',
+                        version: smartAccountVersion?.version ?? 0,
+                        estimationResponse: estimation,
+                        gasToken: token as GasTokenType,
+                    });
                     const tokenBalance = Number(balances.find(t => t.symbol === token)?.balance || 0);
                     // If sending the same token as gas token, need balance for both
                     // If no sendingAmount is provided, we're only checking for gas fees
-                    const additionalAmount = (sendingAmount && sendingTokenSymbol && token === sendingTokenSymbol) 
+                    const additionalAmount = (sendingAmount && sendingTokenSymbol && token === sendingTokenSymbol)
                         ? Number(sendingAmount)
                         : 0;
                     const requiredBalance = gasCost + additionalAmount;
-                    
+
                     if (tokenBalance >= requiredBalance) {
                         // Has enough balance, return this token
                         updatePreferences({ gasTokenToUse: token as GasTokenType });
-                        return { ...estimation, usedToken: token };
+                        return { ...estimation, transactionCost: gasCost, usedToken: token };
                     }
                     // Not enough balance, try next token
                     lastError = new Error(`Insufficient ${token} balance: has ${tokenBalance}, needs ${requiredBalance}`);

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
@@ -1,9 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { EstimationResponse } from '@/types/gasEstimation';
 import { EnhancedClause, GasTokenType } from '@/types';
-import { useSmartAccount, useWallet, estimateGas, useTokenBalances, useGasTokenSelection } from '@/hooks';
+import {
+    useSmartAccount,
+    useWallet,
+    estimateGas,
+    useTokenBalances,
+    useGasTokenSelection,
+    useGetAccountVersion,
+    computeCorrectedTotalGasNoFeePayer,
+    convertGasToGasTokenAmount,
+} from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
+import { ThorClient } from '@vechain/sdk-network';
+import { getConfig } from '@/config';
 
 export interface useGenericDelegatorFeeEstimationParams {
     clauses: EnhancedClause[];
@@ -24,15 +35,32 @@ export const useGenericDelegatorFeeEstimation = ({
     const { data: smartAccount } = useSmartAccount(
         connectedWallet?.address ?? '',
     );
-    const { feeDelegation } = useVeChainKitConfig();
+    const { data: smartAccountVersion } = useGetAccountVersion(
+        smartAccount?.address ?? '',
+        connectedWallet?.address ?? '',
+    );
+    const { feeDelegation, network } = useVeChainKitConfig();
     const { balances } = useTokenBalances(account?.address ?? '');
     const { updatePreferences } = useGasTokenSelection();
+    const thor = ThorClient.at(getConfig(network.type).nodeUrl);
     // Only include essential data in query key to prevent unnecessary refetches
     const queryKey = ['gas-estimation', JSON.stringify(clauses), JSON.stringify(tokens), sendingAmount, sendingTokenSymbol];
 
     return useQuery<EstimationResponse & { usedToken: string }, Error>({
         queryKey,
         queryFn: async () => {
+            // Run the local Thor gas estimate ONCE — the gas number is
+            // token-agnostic so we shouldn't pay for it inside the loop.
+            // Bounded by a timeout so a slow / unreachable node can't
+            // hang the fee-estimation UI forever; on timeout/failure each
+            // token falls back to a delegator-derived value.
+            const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
+                thor,
+                clauses: clauses as TransactionClause[],
+                smartAccountAddress: smartAccount?.address ?? '',
+                version: smartAccountVersion?.version ?? 0,
+            });
+
             let lastError: Error | null = null;
             // Try each token in sequence until one succeeds AND has sufficient balance
             for (const token of tokens) {
@@ -44,20 +72,31 @@ export const useGenericDelegatorFeeEstimation = ({
                         token as GasTokenType,
                         'medium',
                     );
-                    // Check if user has enough balance for this token
-                    const gasCost = estimation.transactionCost;
+                    // The delegator's `transactionCost` is computed from a
+                    // simulation that omits the smart-account auth wrapper
+                    // and can underestimate (or revert outright). Reapply the
+                    // delegator's per-gas rate to our locally-estimated gas
+                    // number so the UI agrees with the actual send path.
+                    const gasCost =
+                        totalGasNoFeePayer !== null
+                            ? convertGasToGasTokenAmount({
+                                  totalGasNoFeePayer,
+                                  gasToken: token as GasTokenType,
+                                  estimationResponse: estimation,
+                              })
+                            : (estimation.transactionCost ?? 0) * 2;
                     const tokenBalance = Number(balances.find(t => t.symbol === token)?.balance || 0);
                     // If sending the same token as gas token, need balance for both
                     // If no sendingAmount is provided, we're only checking for gas fees
-                    const additionalAmount = (sendingAmount && sendingTokenSymbol && token === sendingTokenSymbol) 
+                    const additionalAmount = (sendingAmount && sendingTokenSymbol && token === sendingTokenSymbol)
                         ? Number(sendingAmount)
                         : 0;
                     const requiredBalance = gasCost + additionalAmount;
-                    
+
                     if (tokenBalance >= requiredBalance) {
                         // Has enough balance, return this token
                         updatePreferences({ gasTokenToUse: token as GasTokenType });
-                        return { ...estimation, usedToken: token };
+                        return { ...estimation, transactionCost: gasCost, usedToken: token };
                     }
                     // Not enough balance, try next token
                     lastError = new Error(`Insufficient ${token} balance: has ${tokenBalance}, needs ${requiredBalance}`);

--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegatorFeeEstimation.ts
@@ -8,7 +8,8 @@ import {
     useTokenBalances,
     useGasTokenSelection,
     useGetAccountVersion,
-    computeCorrectedGasTokenCost,
+    computeCorrectedTotalGasNoFeePayer,
+    convertGasToGasTokenAmount,
 } from '@/hooks';
 import { useVeChainKitConfig } from '@/providers';
 import { TransactionClause } from '@vechain/sdk-core';
@@ -48,6 +49,18 @@ export const useGenericDelegatorFeeEstimation = ({
     return useQuery<EstimationResponse & { usedToken: string }, Error>({
         queryKey,
         queryFn: async () => {
+            // Run the local Thor gas estimate ONCE — the gas number is
+            // token-agnostic so we shouldn't pay for it inside the loop.
+            // Bounded by a timeout so a slow / unreachable node can't
+            // hang the fee-estimation UI forever; on timeout/failure each
+            // token falls back to a delegator-derived value.
+            const totalGasNoFeePayer = await computeCorrectedTotalGasNoFeePayer({
+                thor,
+                clauses: clauses as TransactionClause[],
+                smartAccountAddress: smartAccount?.address ?? '',
+                version: smartAccountVersion?.version ?? 0,
+            });
+
             let lastError: Error | null = null;
             // Try each token in sequence until one succeeds AND has sufficient balance
             for (const token of tokens) {
@@ -61,16 +74,17 @@ export const useGenericDelegatorFeeEstimation = ({
                     );
                     // The delegator's `transactionCost` is computed from a
                     // simulation that omits the smart-account auth wrapper
-                    // and can underestimate (or revert outright). Recompute
-                    // locally so the UI agrees with the actual send path.
-                    const gasCost = await computeCorrectedGasTokenCost({
-                        thor,
-                        clauses: clauses as TransactionClause[],
-                        smartAccountAddress: smartAccount?.address ?? '',
-                        version: smartAccountVersion?.version ?? 0,
-                        estimationResponse: estimation,
-                        gasToken: token as GasTokenType,
-                    });
+                    // and can underestimate (or revert outright). Reapply the
+                    // delegator's per-gas rate to our locally-estimated gas
+                    // number so the UI agrees with the actual send path.
+                    const gasCost =
+                        totalGasNoFeePayer !== null
+                            ? convertGasToGasTokenAmount({
+                                  totalGasNoFeePayer,
+                                  gasToken: token as GasTokenType,
+                                  estimationResponse: estimation,
+                              })
+                            : (estimation.transactionCost ?? 0) * 2;
                     const tokenBalance = Number(balances.find(t => t.symbol === token)?.balance || 0);
                     // If sending the same token as gas token, need balance for both
                     // If no sendingAmount is provided, we're only checking for gas fees

--- a/packages/vechain-kit/src/languages/en.json
+++ b/packages/vechain-kit/src/languages/en.json
@@ -500,5 +500,6 @@
   "Tokens sent": "Tokens sent",
   "{{amount}} {{symbol}} is on its way to {{recipient}}.": "{{amount}} {{symbol}} is on its way to {{recipient}}.",
   "NFT sent": "NFT sent",
-  "{{nft}} is now in {{recipient}}’s wallet.": "{{nft}} is now in {{recipient}}’s wallet."
+  "{{nft}} is now in {{recipient}}’s wallet.": "{{nft}} is now in {{recipient}}’s wallet.",
+  "Amount adjusted from {{original}} to {{adjusted}} {{symbol}} to cover the transaction fee.": "Amount adjusted from {{original}} to {{adjusted}} {{symbol}} to cover the transaction fee."
 }

--- a/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
+++ b/packages/vechain-kit/src/providers/VeChainKitProvider.tsx
@@ -290,29 +290,30 @@ const validateConfig = (
         };
     }
 
-    // Check if fee delegation is required based on conditions
-    const requiresFeeDelegation =
-        validatedProps.privy !== undefined ||
-        validatedProps.loginMethods?.some(
-            (method) =>
-                method.method === 'vechain' || method.method === 'ecosystem',
-        );
-
-    // Validate fee delegation
-    if (requiresFeeDelegation) {
-        if (!validatedProps.feeDelegation) {
-            validatedProps.feeDelegation = {
-                genericDelegatorUrl: getGenericDelegatorUrl(),
-            };
-        } else {
-            if (
-                !validatedProps.feeDelegation.delegatorUrl &&
-                !validatedProps.feeDelegation.genericDelegatorUrl
-            ) {
-                validatedProps.feeDelegation.genericDelegatorUrl =
-                    getGenericDelegatorUrl();
-            }
-        }
+    // Auto-inject the default generic-delegator endpoint whenever the
+    // consumer hasn't picked their own delegation strategy.
+    //
+    // We used to gate this on `privy !== undefined || loginMethods includes
+    // 'vechain'/'ecosystem'`, but after #620 every Google/Apple/Twitter/etc.
+    // button silently falls back to the VeChain whitelabel cross-app host
+    // when no host-supplied `privy` prop exists -- meaning users can land
+    // on a smart-account wallet without ever listing 'vechain' in
+    // loginMethods. The old gate then left `feeDelegation` undefined, and
+    // `useGenericDelegatorFeeEstimation` / `useEstimateAllTokens` stayed
+    // permanently disabled (their `enabled` depends on
+    // `feeDelegation?.genericDelegatorUrl`). Always seed the default so
+    // smart-account users have a working fee-delegation path; dapp-kit
+    // wallets simply ignore it.
+    if (!validatedProps.feeDelegation) {
+        validatedProps.feeDelegation = {
+            genericDelegatorUrl: getGenericDelegatorUrl(),
+        };
+    } else if (
+        !validatedProps.feeDelegation.delegatorUrl &&
+        !validatedProps.feeDelegation.genericDelegatorUrl
+    ) {
+        validatedProps.feeDelegation.genericDelegatorUrl =
+            getGenericDelegatorUrl();
     }
 
     // Validate network - always ensure we have a valid network configuration

--- a/packages/vechain-kit/src/theme/input.ts
+++ b/packages/vechain-kit/src/theme/input.ts
@@ -1,0 +1,34 @@
+import {
+    defineStyle,
+    defineStyleConfig,
+    createMultiStyleConfigHelpers,
+} from '@chakra-ui/react';
+import { inputAnatomy } from '@chakra-ui/anatomy';
+
+/**
+ * Force a 16px font size on form inputs so mobile Safari doesn't
+ * auto-zoom on focus. iOS zooms the page whenever a focused input's
+ * computed font-size is below 16px CSS pixels — and the kit's `md`
+ * font token resolves to 14px (see tokens.ts), so the Chakra default
+ * Input/Textarea would land at 14px and trigger the zoom. We pin the
+ * size in absolute pixels rather than `lg` so future token tweaks
+ * can't accidentally regress this.
+ */
+const { definePartsStyle, defineMultiStyleConfig } =
+    createMultiStyleConfigHelpers(inputAnatomy.keys);
+
+export const getInputTheme = () =>
+    defineMultiStyleConfig({
+        baseStyle: definePartsStyle({
+            field: {
+                fontSize: '16px',
+            },
+        }),
+    });
+
+export const getTextareaTheme = () =>
+    defineStyleConfig({
+        baseStyle: defineStyle({
+            fontSize: '16px',
+        }),
+    });

--- a/packages/vechain-kit/src/theme/theme.tsx
+++ b/packages/vechain-kit/src/theme/theme.tsx
@@ -7,6 +7,7 @@ import {
     getCloseButtonTheme,
 } from './button';
 import { getPopoverTheme } from './popover';
+import { getInputTheme, getTextareaTheme } from './input';
 import {
     VechainKitThemeConfig,
     ThemeTokens,
@@ -55,6 +56,8 @@ const getThemeConfig = (
         IconButton: getIconButtonTheme(tokens),
         CloseButton: getCloseButtonTheme(tokens),
         Popover: getPopoverTheme(tokens),
+        Input: getInputTheme(),
+        Textarea: getTextareaTheme(),
     },
     // No global styles - fonts will be applied via component-level styles
     // to ensure they only affect VeChain Kit components, not the host app

--- a/packages/vechain-kit/src/utils/constants.tsx
+++ b/packages/vechain-kit/src/utils/constants.tsx
@@ -11,6 +11,8 @@ import { getConfig } from '@/config';
 import {
     GENERIC_DELEGATOR_MAINNET_URL,
     GENERIC_DELEGATOR_TESTNET_URL,
+    KIT_SPONSORED_DELEGATOR_MAINNET_URL,
+    KIT_SPONSORED_DELEGATOR_TESTNET_URL,
     VECHAIN_KIT_WEBSITE_BASE_URL,
     COINMARKETCAP_STATIC_BASE_URL,
     VECHAIN_TOKEN_REGISTRY_ASSETS_BASE_URL,
@@ -108,6 +110,21 @@ export const getGenericDelegatorUrl = () => {
     return env.isProduction
         ? `${GENERIC_DELEGATOR_MAINNET_URL}/api/v1/`
         : `${GENERIC_DELEGATOR_TESTNET_URL}/api/v1/`; // or url to your delegator
+};
+
+/**
+ * VeChain-sponsored fee-delegator endpoint used by kit-managed onboarding
+ * transactions (claim a VET domain, set a primary name, update profile
+ * text records, etc.) so first-time users with no gas tokens can still
+ * complete these flows. VeChain pays the gas via the configured
+ * sponsor.vechain.energy endpoint; consumer dApps don't need to set up
+ * their own fee delegation to support these kit features.
+ */
+export const getKitSponsoredDelegatorUrl = () => {
+    const env = getENV();
+    return env.isProduction
+        ? KIT_SPONSORED_DELEGATOR_MAINNET_URL
+        : KIT_SPONSORED_DELEGATOR_TESTNET_URL;
 };
 
 export type PrivyEcosystemApp = {


### PR DESCRIPTION
## Summary

Two related bugs in the generic-delegator path that surfaced after merging #620 (cross-app whitelabel host):

- **Bug A — misleading "no gas tokens have sufficient balance" error.** The delegator's `POST /api/v1/estimate/clauses/{token}` simulates the user's raw clauses without the `executeWithAuthorization` wrapper and without the embedded-wallet typed-data signature, so the returned `transactionCost` is too small (or zero for NFT-heavy clauses where simulation reverts). The kit then built a `transferTo<depositAccount>` clause for that insufficient amount; co-signing or submission failed and the error was swallowed by the catch at `useGenericDelegator.ts:223-226`, surfacing the generic *"no gas tokens have sufficient balance or are enabled in Gas Token Preferences"* even when the wallet had ample balance.
- **Bug B — HTTP 404 on `https://mainnet.delegator.vechain.org/api/v1/`.** The cross-app PR added `feeDelegation={{ delegatorUrl: process.env.NEXT_PUBLIC_DELEGATOR_URL! }}` to the homepage example. That sets the kit's `genericDelegator=false` and routes the tx through the regular dApp-sponsored fee-delegator path in `PrivyWalletProvider.signAndSend`, which uses dapp-kit's `ProviderInternalBaseWallet({ gasPayer: { gasPayerServiceUrl } })` and POSTs the bare tx body to the URL — but that endpoint speaks the generic delegator's API (`/sign/transaction/authorized/...`), so the POST 404s.

## What changed

- **`packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts`**
  - New shared helper `computeCorrectedGasTokenCost({ thor, clauses, smartAccountAddress, version, estimationResponse, gasToken })`. It calls `thor.gas.estimateGas` locally (caller = smart account), adds a fixed wrapper overhead per smart-account version, adds a fixed fee-payer overhead per gas token, applies a 1.1 safety multiplier, and converts back to gas-token units using the delegator's rate (`transactionCost / estimatedGas`, falling back to `vthoPerGasAtSpeed * rate * (1 + serviceFee)`).
  - Exported tunable constants: `GENERIC_DELEGATOR_GAS_SAFETY_MULTIPLIER`, `GENERIC_DELEGATOR_FEE_PAYER_OVERHEAD_GAS`, `GENERIC_DELEGATOR_WRAPPER_OVERHEAD_GAS`.
  - `sendTransactionUsingGenericDelegator` now derives the transfer amount from the helper instead of trusting `gasEstimationResponse.transactionCost`. Still one typed-data signature.
  - Safety net: if the local estimate fails, fall back to `transactionCost * 2` rather than 0.
- **`useGenericDelegatorFeeEstimation.ts` / `useEstimateAllTokens.ts`** — call the same helper so the fee-estimation UI matches the send path (no more "you have enough VTHO" → throw on click).
- **`examples/homepage/.../VechainKitProviderWrapper.tsx`** — drop the `feeDelegation` override so the kit falls back to `getGenericDelegatorUrl()` and `genericDelegator=true`. Fixes Bug B.
- **`examples/playground/.../VechainKitProviderWrapper.tsx`** — comment the same override (consistent with homepage).

## Semantic recap of the `feeDelegation` props (no behavior change)

- `feeDelegation.delegatorUrl` → dApp-sponsored mode, the dApp pays user gas.
- `feeDelegation.genericDelegatorUrl` → override the default generic-delegator endpoint, user still pays.
- nothing set → kit injects `getGenericDelegatorUrl()` and uses generic delegator.

## Things intentionally **not** changed

- The error-swallowing catch at `useGenericDelegator.ts:223-226` still re-throws the generic message. Worth surfacing the real `error.cause` in a follow-up.
- No runtime guard yet for consumers who set `feeDelegation.delegatorUrl` to the well-known generic-delegator hosts.

## Test plan

- [ ] `yarn install:all && yarn kit:typecheck && yarn lint` from repo root.
- [ ] Run the homepage example locally with a Privy login, send a small VTHO/VET transfer — confirm network requests go to `…/api/v1/estimate/clauses/...`, `…/api/v1/deposit/account`, `…/api/v1/sign/transaction/authorized/...` and the tx mines.
- [ ] Send an ERC-721 `safeTransferFrom` from a smart account on mainnet (the original repro). The "no gas tokens have sufficient balance" error must not appear when the wallet has a positive balance; the tx should mine and the `transferToGenericDelegatorClause` value should be ≥ the actual gas × token-rate.
- [ ] Repeat for a multi-clause batch (e.g. approve + transfer) on a v3 smart account to validate the v3 wrapper overhead.
- [ ] Calibration log: capture `(rawGasResult.totalGas, totalGas, correctedTransactionCost, on-chain gas used)` for a couple of real sends; adjust `GENERIC_DELEGATOR_WRAPPER_OVERHEAD_GAS` / `GENERIC_DELEGATOR_FEE_PAYER_OVERHEAD_GAS` if the spread is consistently too tight or too loose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable kit-sponsored transaction sponsorship for certain onboarding/domain actions.
  * UI now treats some flows as kit-covered (skips gas selection/requirements).
  * App will label and display “Pay transaction fee” actions when fees are funded by a delegator.

* **Bug Fixes**
  * Improved gas estimation with precomputed totals, safety multipliers, timeouts, and better fallbacks.

* **Chores**
  * Disabled fee-delegation config in example providers.

* **Localization**
  * Added translations for the new fee/payment action labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/vechain-kit/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->