### PR TITLE
fix(swap): block veDelegate from being swapped — v2.10.0

### DIFF
--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.9.0",
+    "version": "2.10.0",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {

--- a/packages/vechain-kit/src/components/AccountModal/Contents/Swap/SwapTokenContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/Swap/SwapTokenContent.tsx
@@ -42,6 +42,11 @@ import { useVeChainKitConfig } from '@/providers';
 import { TOKEN_LOGOS, TOKEN_LOGO_COMPONENTS } from '@/utils';
 import { formatUnits, parseUnits } from 'viem';
 import { compareAddresses, NON_TRANSFERABLE_TOKEN_SYMBOLS } from '@/utils';
+
+const SWAP_EXCLUDED_TOKEN_SYMBOLS: readonly string[] = [
+    ...NON_TRANSFERABLE_TOKEN_SYMBOLS,
+    'veDelegate',
+];
 import { SelectTokenContent } from '../SendToken/SelectTokenContent';
 import { formatCompactCurrency } from '@/utils/currencyUtils';
 import {
@@ -143,7 +148,7 @@ export const SwapTokenContent = ({
                 );
                 if (
                     match &&
-                    !NON_TRANSFERABLE_TOKEN_SYMBOLS.includes(match.symbol)
+                    !SWAP_EXCLUDED_TOKEN_SYMBOLS.includes(match.symbol)
                 ) {
                     setFromToken(match);
                 }
@@ -154,7 +159,7 @@ export const SwapTokenContent = ({
                 );
                 if (
                     match &&
-                    !NON_TRANSFERABLE_TOKEN_SYMBOLS.includes(match.symbol)
+                    !SWAP_EXCLUDED_TOKEN_SYMBOLS.includes(match.symbol)
                 ) {
                     setToToken(match);
                 }
@@ -621,6 +626,7 @@ export const SwapTokenContent = ({
                 onSelectToken={handleSelectFromToken}
                 onBack={() => setStep('main')}
                 showAllTokens={false}
+                excludedTokenSymbols={SWAP_EXCLUDED_TOKEN_SYMBOLS}
             />
         );
     }
@@ -647,6 +653,7 @@ export const SwapTokenContent = ({
                 onSelectToken={handleSelectToToken}
                 onBack={() => setStep('main')}
                 showAllTokens={true}
+                excludedTokenSymbols={SWAP_EXCLUDED_TOKEN_SYMBOLS}
             />
         );
     }

--- a/packages/vechain-kit/src/components/AccountModal/Contents/TokenDetail/TokenDetailContent.tsx
+++ b/packages/vechain-kit/src/components/AccountModal/Contents/TokenDetail/TokenDetailContent.tsx
@@ -92,6 +92,7 @@ export const TokenDetailContent = ({
     const isNonTransferable = NON_TRANSFERABLE_TOKEN_SYMBOLS.includes(
         token.symbol,
     );
+    const isNonSwappable = isNonTransferable || token.symbol === 'veDelegate';
 
     const amountNumber = Number(token.balance);
     const balanceText = amountNumber.toLocaleString(undefined, {
@@ -237,7 +238,7 @@ export const TokenDetailContent = ({
                                 icon={LuArrowLeftRight}
                                 label="Swap"
                                 onClick={handleSwap}
-                                isDisabled={isNonTransferable}
+                                isDisabled={isNonSwappable}
                             />
                             <ActionIconButton
                                 icon={LuArrowUpFromLine}


### PR DESCRIPTION
## Summary
- veDelegate is no longer selectable as either side of a swap (excluded from the from/to token lists).
- The "Swap" action on the veDelegate token detail screen is now disabled.
- Bump kit to 2.10.0.

veDelegate remains transferable via the Send flow — only swapping is blocked.

## Test plan
- [ ] Open the account modal → Swap → "From" picker: veDelegate is hidden
- [ ] Open the account modal → Swap → "To" picker: veDelegate is hidden
- [ ] Open the veDelegate token detail: the Swap action button is disabled
- [ ] VOT3 still excluded from swap (regression check)
- [ ] Send flow still lists veDelegate (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded token swap restrictions to prevent swapping of additional tokens, ensuring consistent exclusion across all swap flows.

* **Chores**
  * Version bumped to 2.10.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/vechain-kit/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->