### PR TITLE
ci(cross-app): skip workflows on kit-only changes

### DIFF
--- a/.github/workflows/cross-app-connect-check.yaml
+++ b/.github/workflows/cross-app-connect-check.yaml
@@ -8,7 +8,6 @@ on:
             - main
         paths:
             - 'cross-app-connect/**'
-            - 'packages/vechain-kit/**'
             - 'yarn.lock'
             - '.github/workflows/cross-app-connect-check.yaml'
 

--- a/.github/workflows/cross-app-connect-deploy.yaml
+++ b/.github/workflows/cross-app-connect-deploy.yaml
@@ -6,7 +6,6 @@ on:
             - main
         paths:
             - 'cross-app-connect/**'
-            - 'packages/vechain-kit/**'
             - 'yarn.lock'
             - '.github/workflows/cross-app-connect-deploy.yaml'
     workflow_dispatch:


### PR DESCRIPTION
## Summary
- `cross-app-connect` has **no dependency** on `@vechain/vechain-kit` (checked `cross-app-connect/package.json`), so kit-only changes can't affect its build or what gets deployed.
- Drop `packages/vechain-kit/**` from the `paths:` filter of both the PR check and the Pages deploy workflows.
- Net effect: opening a PR or merging to `main` that only touches the kit no longer runs cross-app type-check/build or redeploys the Pages site.

Path filters kept (still legit triggers):
- `cross-app-connect/**`
- `yarn.lock` (shared lockfile — dep updates can still affect cross-app's build)
- the workflow file itself

## Test plan
- [ ] Open a kit-only PR → Cross-App Connect — Check does **not** start
- [ ] Open a PR touching `cross-app-connect/**` → check runs as before
- [ ] Merge a kit-only commit to `main` → no Pages deploy
- [ ] Merge a `cross-app-connect/**` commit to `main` → Pages deploy runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)