### PR TITLE
fix(connect-modal): close stuck dapp-kit WC QR modal after handshake

### DIFF
--- a/packages/vechain-kit/src/hooks/login/useConnectWithDappKitSource.ts
+++ b/packages/vechain-kit/src/hooks/login/useConnectWithDappKitSource.ts
@@ -1,7 +1,7 @@
 import { WalletSource } from '@vechain/dapp-kit';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDAppKitWallet } from '@/hooks';
+import { useDAppKitWallet, useDAppKitWalletModal } from '@/hooks';
 import { isRejectionError } from '@/utils/stringUtils';
 import type { ConnectModalContentsTypes } from '@/components';
 
@@ -57,6 +57,7 @@ export const useConnectWithDappKitSource = (
 ) => {
     const { t } = useTranslation();
     const { setSource, connect: dappKitConnect } = useDAppKitWallet();
+    const { close: closeDappKitModal } = useDAppKitWalletModal();
 
     const connect = useCallback(async () => {
         const displayName = sourceDisplayName[source] ?? source;
@@ -101,8 +102,23 @@ export const useConnectWithDappKitSource = (
         try {
             setSource(source);
             await dappKitConnect();
-            // ConnectModal closes automatically when useWallet flips
-            // `connection.isConnected` to true.
+            // WalletConnect side-effect: setSource('wallet-connect') +
+            // connect() causes dapp-kit's signer to call
+            // CustomWalletConnectModal.openModal({uri}), which fires
+            // `vdk-open-wc-qrcode` and pops dapp-kit-ui's own
+            // <vdk-connect-modal> with the QR. That modal only
+            // auto-closes when the user clicks through dapp-kit-ui's
+            // source picker — since we drive connect from here, we have
+            // to close it ourselves. If we don't, the QR modal stays up
+            // post-handshake and the user's only out (clicking X) hits
+            // dapp-kit-ui's `handleClose`, which calls `wallet.disconnect()`
+            // whenever `walletConnectQRcode` is set — i.e. closing the
+            // stuck modal disconnects the user we just connected.
+            if (source === 'wallet-connect') {
+                closeDappKitModal();
+            }
+            // Our own ConnectModal closes automatically when useWallet
+            // flips `connection.isConnected` to true.
         } catch (err) {
             const errorMsg = extractErrorMessage(err);
             if (isRejectionError(errorMsg)) {
@@ -120,7 +136,14 @@ export const useConnectWithDappKitSource = (
                 },
             });
         }
-    }, [source, setSource, dappKitConnect, setCurrentContent, t]);
+    }, [
+        source,
+        setSource,
+        dappKitConnect,
+        closeDappKitModal,
+        setCurrentContent,
+        t,
+    ]);
 
     return { connect };
 };


### PR DESCRIPTION
## Summary

Fixes a WalletConnect bug introduced with the custom connect modal in #611.

When a user picked WalletConnect from vechain-kit's own modal, scanned the QR with their phone and approved, the kit reflected the connection in the background (button showed the connected address/domain) — but dapp-kit-ui's QR modal stayed open on top, and clicking its X disconnected the user we'd just connected.

## Root cause

`setSource('wallet-connect') + connect()` causes dapp-kit's signer to call `CustomWalletConnectModal.openModal({ uri })`, which fires the `vdk-open-wc-qrcode` event and pops dapp-kit-ui's own `<vdk-connect-modal>` to display the QR.

That modal **only auto-closes** when the user clicked through dapp-kit-ui's own `onSourceClick` handler — it calls `n.modal.close()` after `wallet.connect()` resolves (gated by `alwaysShowConnect`, which we have on). Because we drive the connect from `useConnectWithDappKitSource`, that path never runs and the QR modal stays up.

And the modal's X button triggers:

```js
this.handleClose = () => {
    n.modal.close(),
    this.walletConnectQRcode && setTimeout(() => {
        this.handleBack(),
        this.wallet.disconnect()   // ← disconnects the user
    }, 500),
    ...
};
```

Since `walletConnectQRcode` is still set after a successful handshake, the X disconnects the freshly-connected wallet.

Using `useDAppKitWalletModal()` directly avoids this because the user-click goes through dapp-kit-ui's `onSourceClick`, which does call `n.modal.close()` post-handshake.

## Fix

After `dappKitConnect()` resolves for `wallet-connect`, call `useDAppKitWalletModal().close()`. That dispatches `vdk-close-wallet-modal`, whose only listener sets `open = false` — no disconnect side effect, since the disconnect path lives inside `handleClose`, not the close-event listener.

## Test plan

- [ ] WalletConnect: open vechain-kit connect modal → click WalletConnect → QR modal appears → scan with VeWorld mobile → approve → both modals close automatically, button shows connected address
- [ ] WalletConnect: open vechain-kit connect modal → click WalletConnect → close the QR modal with X before scanning → modal closes, no connection established (existing behavior preserved)
- [ ] VeWorld: unchanged flow still works (extension prompt, no dapp-kit-ui modal involved)
- [ ] Sync2: unchanged flow still works
- [ ] `loginMethods=['dappkit']` legacy path still routes through `useDAppKitWalletModal()` directly and behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the QR modal for WalletConnect would remain open after a successful connection attempt, which could interfere with disconnect functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/vechain-kit/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->