### PR TITLE
fix(ci): unblock app-hub refresh workflow (duplicate Authorization header)

### DIFF
--- a/.github/workflows/cross-app-connect-refresh-app-hub.yaml
+++ b/.github/workflows/cross-app-connect-refresh-app-hub.yaml
@@ -29,6 +29,11 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                  # peter-evans/create-pull-request manages its own git auth; leaving
+                  # checkout's extraheader in place produces a duplicate Authorization
+                  # header and GitHub rejects the push with HTTP 400.
+                  persist-credentials: false
 
             - name: Setup Node
               uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
## Summary

- `actions/checkout@v6` writes a basic-auth `http.https://github.com/.extraheader` and keeps it after the step finishes.
- `peter-evans/create-pull-request@v7` then layers its own credentials on top, so git sends two `Authorization` headers and GitHub rejects with HTTP 400 on `git remote prune origin`.
- Setting `persist-credentials: false` on the checkout step lets the PR action own auth alone, which is what its own docs recommend.

Failure observed on the scheduled run:

\`\`\`
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/vechain/vechain-kit/': The requested URL returned error: 400
Error: The process '/usr/bin/git' failed with exit code 128
\`\`\`

## Test plan

- [ ] Manually trigger `Cross-App Connect — Refresh App Hub cache` via `workflow_dispatch` and confirm the job reaches the `Open PR if anything changed` step without the duplicate-header error.
- [ ] If the registry has diffs, confirm the PR opens against `main` on the `chore/refresh-app-hub-cache` branch as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an authentication issue with the scheduled Cross-App Connect App Hub cache refresh workflow. The workflow now completes successfully without encountering authorization errors during automated cache updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->