### PR TITLE
chore: update dapp-kit to 2.3.0

### DIFF
--- a/examples/next-template/next.config.js
+++ b/examples/next-template/next.config.js
@@ -4,6 +4,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? '
 const nextConfig = {
     basePath,
     assetPrefix: basePath,
+    allowedDevOrigins: ['observe-devices-sara-handhelds.trycloudflare.com'],
     output: 'export',
     distDir: 'dist',
 

--- a/examples/next-template/next.config.js
+++ b/examples/next-template/next.config.js
@@ -4,7 +4,6 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? '
 const nextConfig = {
     basePath,
     assetPrefix: basePath,
-    allowedDevOrigins: ['observe-devices-sara-handhelds.trycloudflare.com'],
     output: 'export',
     distDir: 'dist',
 

--- a/examples/next-template/tsconfig.json
+++ b/examples/next-template/tsconfig.json
@@ -1,43 +1,56 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "noEmit": true,
-        "esModuleInterop": true,
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "resolveJsonModule": true,
-        "allowImportingTsExtensions": true,
-        "isolatedModules": true,
-        "jsx": "preserve",
-        "incremental": true,
-        "tsBuildInfoFile": ".next/.tsbuildinfo",
-        // Performance optimizations
-        "assumeChangesOnlyAffectDirectDependencies": true,
-        "plugins": [
-            {
-                "name": "next"
-            }
-        ],
-        "paths": {
-            "@/*": ["./src/*"],
-            "@vechain-kit/*": ["../../packages/vechain-kit/src/*"]
-        }
-    },
-    "include": [
-        "next-env.d.ts",
-        "**/*.ts",
-        "**/*.tsx",
-        ".next/types/**/*.ts",
-        "dist/types/**/*.ts",
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
     ],
-    "exclude": ["node_modules", ".next", "dist"],
-    "ts-node": {
-        "compilerOptions": {
-            "module": "CommonJS"
-        }
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "tsBuildInfoFile": ".next/.tsbuildinfo",
+    // Performance optimizations
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ],
+      "@vechain-kit/*": [
+        "../../packages/vechain-kit/src/*"
+      ]
     }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "dist/types/**/*.ts",
+    "dist/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next",
+    "dist"
+  ],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  }
 }

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -64,7 +64,7 @@
         "@tanstack/react-query": "^5.64.2",
         "@tanstack/react-query-devtools": "^5.64.1",
         "@vechain/contract-getters": "1.3.0",
-        "@vechain/dapp-kit-react": "2.2.0",
+        "@vechain/dapp-kit-react": "2.3.0",
         "@vechain/picasso": "^2.1.1",
         "@vechain/vechain-contract-types": "1.6.0-rc",
         "@wagmi/core": "^2.17.2",
@@ -103,7 +103,7 @@
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
         "@tanstack/react-query": "^5.64.2",
-        "@vechain/dapp-kit-react": "2.2.0",
+        "@vechain/dapp-kit-react": "2.3.0",
         "framer-motion": "^11.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7727,24 +7727,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit-react@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@vechain/dapp-kit-react@npm:2.2.0"
+"@vechain/dapp-kit-react@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@vechain/dapp-kit-react@npm:2.3.0"
   dependencies:
     "@lit/react": "npm:^1.0.7"
-    "@vechain/dapp-kit": "npm:2.2.0"
-    "@vechain/dapp-kit-ui": "npm:2.2.0"
+    "@vechain/dapp-kit": "npm:2.3.0"
+    "@vechain/dapp-kit-ui": "npm:2.3.0"
     "@vechain/sdk-core": "npm:^2.0.0"
     valtio: "npm:1.13.2"
-  checksum: 10c0/bb4b099cc64feeef5b136944314f980c651facab9b368fa40dbd3892e5fac66aa229cf93ef9eb7401538f572566ecef2a6afebf4fcd8b7d032dd1b6531547eba
+  checksum: 10c0/7038cc3112b98449ec09fc13d4e92796e000b2ba2c54492a2fbb2b3cfb840fe4d69d74ef95d2da9529f96f839fc91e66995285c978ce13beb6bbfbe4372dc2c9
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit-ui@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@vechain/dapp-kit-ui@npm:2.2.0"
+"@vechain/dapp-kit-ui@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@vechain/dapp-kit-ui@npm:2.3.0"
   dependencies:
-    "@vechain/dapp-kit": "npm:2.2.0"
+    "@vechain/dapp-kit": "npm:2.3.0"
     "@vechain/picasso": "npm:2.1.1"
     "@vechain/sdk-core": "npm:^2.0.0"
     "@vechain/sdk-network": "npm:^2.0.0"
@@ -7754,13 +7754,13 @@ __metadata:
     lit: "npm:3.2.1"
     qrcode: "npm:1.5.4"
     valtio: "npm:1.13.2"
-  checksum: 10c0/6da4b5286130a904955f6c47f081947c79bd393a44d0f2f83e015db9192dbce3015002fb989951674681a15a9e744807f82e6181ee9378c42f572063a12caa3c
+  checksum: 10c0/47b6778053642139897cd16fc58cab7184104c7f4362ec55b41500f097cf7917282bfbf7b338b0f9edb00de01fa23fc858f70c268d2bea835c9bf7edc36df6ab
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@vechain/dapp-kit@npm:2.2.0"
+"@vechain/dapp-kit@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@vechain/dapp-kit@npm:2.3.0"
   dependencies:
     "@vechain/connex-wallet-buddy": "npm:^0.1.12"
     "@vechain/sdk-core": "npm:^2.0.0"
@@ -7772,7 +7772,7 @@ __metadata:
     events: "npm:^3.3.0"
     valtio: "npm:1.13.2"
     viem: "npm:2.23.2"
-  checksum: 10c0/7681190a2e5215db3a9d5e12006a77c41fb42aae69e1ab5457dcb9d99b2007dd6ce4f14137117a516cff9e33a0cd9646ed795a7443ba9fcc1063a776c5cd59d0
+  checksum: 10c0/5a092846e087fb010330958e748c5d8da1d05f58d8465f068f7b177def7f13e86d53720b60b60153059d83e4f514809c64ce1511a2b8f3a40813314a467cdee2
   languageName: node
   linkType: hard
 
@@ -7926,7 +7926,7 @@ __metadata:
     "@types/react": "npm:^18.2.28"
     "@types/react-dom": "npm:^18.2.13"
     "@vechain/contract-getters": "npm:1.3.0"
-    "@vechain/dapp-kit-react": "npm:2.2.0"
+    "@vechain/dapp-kit-react": "npm:2.3.0"
     "@vechain/picasso": "npm:^2.1.1"
     "@vechain/vechain-contract-types": "npm:1.6.0-rc"
     "@wagmi/core": "npm:^2.17.2"
@@ -7960,7 +7960,7 @@ __metadata:
     "@emotion/react": ^11.0.0
     "@emotion/styled": ^11.0.0
     "@tanstack/react-query": ^5.64.2
-    "@vechain/dapp-kit-react": 2.2.0
+    "@vechain/dapp-kit-react": 2.3.0
     framer-motion: ^11.0.0
     react: ^18.0.0
     react-dom: ^18.0.0


### PR DESCRIPTION
## Summary
- Updates `@vechain/dapp-kit-react` from `2.2.0` to `2.3.0` in VeChain Kit dependencies and peer dependencies.
- Refreshes `yarn.lock` so `@vechain/dapp-kit`, `@vechain/dapp-kit-ui`, and `@vechain/dapp-kit-react` resolve to `2.3.0`.
- Allows the current Cloudflare tunnel origin for the Next template dev server.

## Test plan
- Ran `yarn install`.
- Started `next-template` dev server on port `3002` with the VeChain Kit watcher.
- Verified local and Cloudflare tunnel endpoints returned HTTP 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@vechain/dapp-kit-react` dependency to version 2.3.0 in both dependencies and peer dependencies
  * Added development origin configuration for Cloudflare tunnel support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->