### PR TITLE
chore: bump dapp-kit to 2.3.2

### DIFF
--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -64,7 +64,7 @@
         "@tanstack/react-query": "^5.64.2",
         "@tanstack/react-query-devtools": "^5.64.1",
         "@vechain/contract-getters": "1.3.0",
-        "@vechain/dapp-kit-react": "2.2.0",
+        "@vechain/dapp-kit-react": "2.3.1",
         "@vechain/picasso": "^2.1.1",
         "@vechain/vechain-contract-types": "1.6.0-rc",
         "@wagmi/core": "^2.17.2",
@@ -103,7 +103,7 @@
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
         "@tanstack/react-query": "^5.64.2",
-        "@vechain/dapp-kit-react": "2.2.0",
+        "@vechain/dapp-kit-react": "2.3.1",
         "framer-motion": "^11.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {

--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -64,7 +64,7 @@
         "@tanstack/react-query": "^5.64.2",
         "@tanstack/react-query-devtools": "^5.64.1",
         "@vechain/contract-getters": "1.3.0",
-        "@vechain/dapp-kit-react": "2.3.1",
+        "@vechain/dapp-kit-react": "2.3.2",
         "@vechain/picasso": "^2.1.1",
         "@vechain/vechain-contract-types": "1.6.0-rc",
         "@wagmi/core": "^2.17.2",
@@ -103,7 +103,7 @@
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
         "@tanstack/react-query": "^5.64.2",
-        "@vechain/dapp-kit-react": "2.3.1",
+        "@vechain/dapp-kit-react": "2.3.2",
         "framer-motion": "^11.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7727,24 +7727,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit-react@npm:2.3.1":
-  version: 2.3.1
-  resolution: "@vechain/dapp-kit-react@npm:2.3.1"
+"@vechain/dapp-kit-react@npm:2.3.2":
+  version: 2.3.2
+  resolution: "@vechain/dapp-kit-react@npm:2.3.2"
   dependencies:
     "@lit/react": "npm:^1.0.7"
-    "@vechain/dapp-kit": "npm:2.3.1"
-    "@vechain/dapp-kit-ui": "npm:2.3.1"
+    "@vechain/dapp-kit": "npm:2.3.2"
+    "@vechain/dapp-kit-ui": "npm:2.3.2"
     "@vechain/sdk-core": "npm:^2.0.0"
     valtio: "npm:1.13.2"
-  checksum: 10c0/a01b9f1e381f02ca669772af38bf0a7d079fd616ad64397f930ae68f13466f86aca760f446c231aa515d94e1672f7bc8b33999f5d5eda430863029c82c420eca
+  checksum: 10c0/0a82b437a24720a80cb7b6b5b2d3f5a8e332183df4e43192eaf9d8e02dc3aaf05f017e3555eae8a9c7d25da1353d8c6b3094a1c78b6f0f0f1ad7adedfcbb2c70
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit-ui@npm:2.3.1":
-  version: 2.3.1
-  resolution: "@vechain/dapp-kit-ui@npm:2.3.1"
+"@vechain/dapp-kit-ui@npm:2.3.2":
+  version: 2.3.2
+  resolution: "@vechain/dapp-kit-ui@npm:2.3.2"
   dependencies:
-    "@vechain/dapp-kit": "npm:2.3.1"
+    "@vechain/dapp-kit": "npm:2.3.2"
     "@vechain/picasso": "npm:2.1.1"
     "@vechain/sdk-core": "npm:^2.0.0"
     "@vechain/sdk-network": "npm:^2.0.0"
@@ -7754,13 +7754,13 @@ __metadata:
     lit: "npm:3.2.1"
     qrcode: "npm:1.5.4"
     valtio: "npm:1.13.2"
-  checksum: 10c0/16044afb51f6598afd7369cb2aec1434dac04ff6e3715aa7d5adbdeb11104e45118668ad527a0f199e4b5ef5771e93a9b9712d7b213704cfdc9317e0189368a9
+  checksum: 10c0/64839d943adcc5cac6aabc043229bfd8ce021d94080e3cb6f7026494c1b5d639596d1f7d270f3d9773f6b81827453776c278786bc6615a4b8f65ecfa8ea05438
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit@npm:2.3.1":
-  version: 2.3.1
-  resolution: "@vechain/dapp-kit@npm:2.3.1"
+"@vechain/dapp-kit@npm:2.3.2":
+  version: 2.3.2
+  resolution: "@vechain/dapp-kit@npm:2.3.2"
   dependencies:
     "@vechain/connex-wallet-buddy": "npm:^0.1.12"
     "@vechain/sdk-core": "npm:^2.0.0"
@@ -7772,7 +7772,7 @@ __metadata:
     events: "npm:^3.3.0"
     valtio: "npm:1.13.2"
     viem: "npm:2.23.2"
-  checksum: 10c0/53b3b1fbb34c525e09a6c8e813af1c685e9daf199f7ff22d54f2b5131bf3fb1a438eb46d3b1952a5e2dbe4522ff99ad3fe210440040c296dbf9f5dd6b63f9293
+  checksum: 10c0/683d3ec4346fe5489601dedc30026fbc86193237a16be084692facb0cab6ca1928ec2a203e14539ce7eabc28f55d9d2906fdbc7f321db3e5feaff7d774670e5b
   languageName: node
   linkType: hard
 
@@ -7926,7 +7926,7 @@ __metadata:
     "@types/react": "npm:^18.2.28"
     "@types/react-dom": "npm:^18.2.13"
     "@vechain/contract-getters": "npm:1.3.0"
-    "@vechain/dapp-kit-react": "npm:2.3.1"
+    "@vechain/dapp-kit-react": "npm:2.3.2"
     "@vechain/picasso": "npm:^2.1.1"
     "@vechain/vechain-contract-types": "npm:1.6.0-rc"
     "@wagmi/core": "npm:^2.17.2"
@@ -7960,7 +7960,7 @@ __metadata:
     "@emotion/react": ^11.0.0
     "@emotion/styled": ^11.0.0
     "@tanstack/react-query": ^5.64.2
-    "@vechain/dapp-kit-react": 2.3.1
+    "@vechain/dapp-kit-react": 2.3.2
     framer-motion: ^11.0.0
     react: ^18.0.0
     react-dom: ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7727,24 +7727,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit-react@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@vechain/dapp-kit-react@npm:2.2.0"
+"@vechain/dapp-kit-react@npm:2.3.1":
+  version: 2.3.1
+  resolution: "@vechain/dapp-kit-react@npm:2.3.1"
   dependencies:
     "@lit/react": "npm:^1.0.7"
-    "@vechain/dapp-kit": "npm:2.2.0"
-    "@vechain/dapp-kit-ui": "npm:2.2.0"
+    "@vechain/dapp-kit": "npm:2.3.1"
+    "@vechain/dapp-kit-ui": "npm:2.3.1"
     "@vechain/sdk-core": "npm:^2.0.0"
     valtio: "npm:1.13.2"
-  checksum: 10c0/bb4b099cc64feeef5b136944314f980c651facab9b368fa40dbd3892e5fac66aa229cf93ef9eb7401538f572566ecef2a6afebf4fcd8b7d032dd1b6531547eba
+  checksum: 10c0/a01b9f1e381f02ca669772af38bf0a7d079fd616ad64397f930ae68f13466f86aca760f446c231aa515d94e1672f7bc8b33999f5d5eda430863029c82c420eca
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit-ui@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@vechain/dapp-kit-ui@npm:2.2.0"
+"@vechain/dapp-kit-ui@npm:2.3.1":
+  version: 2.3.1
+  resolution: "@vechain/dapp-kit-ui@npm:2.3.1"
   dependencies:
-    "@vechain/dapp-kit": "npm:2.2.0"
+    "@vechain/dapp-kit": "npm:2.3.1"
     "@vechain/picasso": "npm:2.1.1"
     "@vechain/sdk-core": "npm:^2.0.0"
     "@vechain/sdk-network": "npm:^2.0.0"
@@ -7754,13 +7754,13 @@ __metadata:
     lit: "npm:3.2.1"
     qrcode: "npm:1.5.4"
     valtio: "npm:1.13.2"
-  checksum: 10c0/6da4b5286130a904955f6c47f081947c79bd393a44d0f2f83e015db9192dbce3015002fb989951674681a15a9e744807f82e6181ee9378c42f572063a12caa3c
+  checksum: 10c0/16044afb51f6598afd7369cb2aec1434dac04ff6e3715aa7d5adbdeb11104e45118668ad527a0f199e4b5ef5771e93a9b9712d7b213704cfdc9317e0189368a9
   languageName: node
   linkType: hard
 
-"@vechain/dapp-kit@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@vechain/dapp-kit@npm:2.2.0"
+"@vechain/dapp-kit@npm:2.3.1":
+  version: 2.3.1
+  resolution: "@vechain/dapp-kit@npm:2.3.1"
   dependencies:
     "@vechain/connex-wallet-buddy": "npm:^0.1.12"
     "@vechain/sdk-core": "npm:^2.0.0"
@@ -7772,7 +7772,7 @@ __metadata:
     events: "npm:^3.3.0"
     valtio: "npm:1.13.2"
     viem: "npm:2.23.2"
-  checksum: 10c0/7681190a2e5215db3a9d5e12006a77c41fb42aae69e1ab5457dcb9d99b2007dd6ce4f14137117a516cff9e33a0cd9646ed795a7443ba9fcc1063a776c5cd59d0
+  checksum: 10c0/53b3b1fbb34c525e09a6c8e813af1c685e9daf199f7ff22d54f2b5131bf3fb1a438eb46d3b1952a5e2dbe4522ff99ad3fe210440040c296dbf9f5dd6b63f9293
   languageName: node
   linkType: hard
 
@@ -7926,7 +7926,7 @@ __metadata:
     "@types/react": "npm:^18.2.28"
     "@types/react-dom": "npm:^18.2.13"
     "@vechain/contract-getters": "npm:1.3.0"
-    "@vechain/dapp-kit-react": "npm:2.2.0"
+    "@vechain/dapp-kit-react": "npm:2.3.1"
     "@vechain/picasso": "npm:^2.1.1"
     "@vechain/vechain-contract-types": "npm:1.6.0-rc"
     "@wagmi/core": "npm:^2.17.2"
@@ -7960,7 +7960,7 @@ __metadata:
     "@emotion/react": ^11.0.0
     "@emotion/styled": ^11.0.0
     "@tanstack/react-query": ^5.64.2
-    "@vechain/dapp-kit-react": 2.2.0
+    "@vechain/dapp-kit-react": 2.3.1
     framer-motion: ^11.0.0
     react: ^18.0.0
     react-dom: ^18.0.0


### PR DESCRIPTION
## Summary
- Bumps `@vechain/dapp-kit-react` to `2.3.2` in `@vechain/vechain-kit` dependencies and peer dependencies.
- Updates `yarn.lock` so `@vechain/dapp-kit`, `@vechain/dapp-kit-ui`, and `@vechain/dapp-kit-react` resolve to `2.3.2` from npm.

## Test plan
- Ran `yarn install` successfully.
- Verified installed package versions resolve to `2.3.2`.
- Restarted `next-template` locally and confirmed `http://localhost:3002` returns `200`.
- Started a Cloudflare tunnel and confirmed the active tunnel returned `200`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@vechain/dapp-kit-react` dependency from version 2.2.0 to 2.3.2 across all dependency declarations to ensure version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->