### PR TITLE
ci: split preview deploy so PR code never holds id-token

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -43,34 +43,41 @@ jobs:
                   issue-number: ${{ github.event.pull_request.number }}
                   body: |
                       ## 👋 Thanks for your contribution!
-                      
+
                       Since this PR comes from a forked repository, preview deployment requires approval from a maintainer for security reasons.
                       Please ensure that your PR branch name starts with your GitHub username in the format of <username>/<branch-name>. Eg. myusername/my-feature **not main**
-                      
+
                       **Next steps:**
                       1. A maintainer will review your code
                       2. If approved, they'll add the `safe-to-deploy` label to trigger deployment
                       3. **After each new commit**, the maintainer will need to remove and re-add the label for security
-                      
+
                       This ensures every version of the code is explicitly reviewed before deployment. Thank you for your patience! 🙏
 
-    # Job 2: Deploy (runs for internal PRs OR when external PR gets labeled)
-    deploy:
+    # Job 2: Build the PR's code.
+    #
+    # This is the only job that runs code from the pull request head, so it is
+    # deliberately the job with no `id-token: write`. Everything the build can
+    # reach is scoped to this job: without the id-token permission there is no
+    # OIDC token to request here, so a malicious dependency or build script in a
+    # fork cannot obtain AWS credentials. The deploy job below holds the
+    # permission but never executes PR code.
+    build:
         runs-on: ubuntu-latest
         permissions:
-            id-token: write
-            pull-requests: write
+            contents: read
         # Security gate: Only run when 'safe-to-deploy' label is ADDED OR from internal branch
         if: |
             (github.event.label.name == 'safe-to-deploy') ||
             (github.event.pull_request.head.repo.full_name == github.repository) && github.event.pull_request.head.ref != 'main'
+        outputs:
+            processedBranchName: ${{ steps.process-branch-name.outputs.processedBranchName }}
         env:
             NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
             NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
             NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
             NEXT_PUBLIC_DELEGATOR_URL: ${{ secrets.NEXT_PUBLIC_DELEGATOR_URL }}
             NEXT_PUBLIC_NETWORK_TYPE: 'main'
-            AWS_REGION: eu-west-1
             BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         steps:
             - name: Check branch name prefix (for external PRs)
@@ -90,6 +97,8 @@ jobs:
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
+                  # Do not leave the token in .git/config for the build to find.
+                  persist-credentials: false
 
             - name: Process Branch Name
               id: process-branch-name
@@ -113,6 +122,34 @@ jobs:
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                   done
 
+            - name: Upload built site
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: homepage-dist
+                  path: ./examples/homepage/dist
+                  retention-days: 1
+                  if-no-files-found: error
+
+    # Job 3: Publish the built site.
+    #
+    # Holds `id-token: write` but never checks out or runs PR code - it only
+    # downloads the artifact and copies it to S3. `aws s3 sync` transfers file
+    # contents, it does not execute them.
+    deploy:
+        runs-on: ubuntu-latest
+        needs: build
+        permissions:
+            id-token: write
+            pull-requests: write
+        env:
+            AWS_REGION: eu-west-1
+        steps:
+            - name: Download built site
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  name: homepage-dist
+                  path: ./dist
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
               with:
@@ -120,8 +157,11 @@ jobs:
                   aws-region: ${{ env.AWS_REGION }}
 
             - name: Deploy to S3
+              env:
+                  PREVIEW_BUCKET: ${{ secrets.AWS_PREVIEW_BUCKET_NAME }}
+                  PREVIEW_PREFIX: ${{ needs.build.outputs.processedBranchName }}
               run: |
-                  aws s3 sync ./examples/homepage/dist s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ steps.process-branch-name.outputs.processedBranchName }} --delete
+                  aws s3 sync ./dist "s3://${PREVIEW_BUCKET}/${PREVIEW_PREFIX}" --delete
 
             - name: Cloudfront Invalidation
               run: |
@@ -142,5 +182,5 @@ jobs:
                   issue-number: ${{ github.event.pull_request.number }}
                   body: |
                       # 🚀 Preview environment deployed!
-                      Preview URL: https://preview.vechainkit.vechain.org/${{ steps.process-branch-name.outputs.processedBranchName }}
+                      Preview URL: https://preview.vechainkit.vechain.org/${{ needs.build.outputs.processedBranchName }}
                   edit-mode: replace

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -139,8 +139,8 @@ jobs:
         runs-on: ubuntu-latest
         needs: build
         permissions:
-            id-token: write
-            pull-requests: write
+            id-token: write # mint the OIDC token exchanged for the deploy role
+            pull-requests: write # post or update the preview URL comment
         env:
             AWS_REGION: eu-west-1
         steps:
@@ -164,8 +164,10 @@ jobs:
                   aws s3 sync ./dist "s3://${PREVIEW_BUCKET}/${PREVIEW_PREFIX}" --delete
 
             - name: Cloudfront Invalidation
+              env:
+                  DISTRIBUTION_ID: ${{ secrets.AWS_PREVIEW_CLOUDFRONT_DISTRIBUTION_ID }}
               run: |
-                  AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PREVIEW_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/' '/*'
+                  AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths '/' '/*'
 
             - name: Find Comment
               uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0


### PR DESCRIPTION
## Problem

In `deploy-preview.yaml`, a single `deploy` job did all of this:

1. declared `permissions: id-token: write`
2. checked out `github.event.pull_request.head.sha`
3. ran `yarn install` / `yarn install:all` / `yarn build`
4. configured AWS credentials and published

Job-level `permissions` apply to the whole job, not from a given step onwards. So the OIDC token was obtainable at step 3 as much as at step 4 — build tooling from the pull request (a dependency lifecycle script, a build plugin, a patched config) ran in a job that could request one. The AWS step being last does not help.

The `safe-to-deploy` label does gate this for forks, and it is implemented correctly — `github.event.label.name` is null on `synchronize`, so a new commit really does need the label re-added. But the gate asks a maintainer to approve *a preview deploy*, and what it actually authorizes is broader than that. That is a lot to hang on one label.

## Change

Split into `build` and `deploy`.

| | runs PR code | `id-token` |
|---|---|---|
| `build` | yes — checkout of `head.sha`, `yarn install`, `yarn build` | **no** |
| `deploy` | no — downloads an artifact, `aws s3 sync` | yes |

There is no OIDC token to request in the job where PR code runs, so the credential path is closed by construction rather than by step ordering. `deploy` never checks out the repository and runs no code from it; `aws s3 sync` transfers file contents.

Also in this PR:

- `persist-credentials: false` on the checkout, so the build cannot find a token in `.git/config`.
- The S3 prefix goes through `env:` instead of being interpolated directly into the `run` block. It was already sanitised to `[a-z0-9-]`, so this is tidying rather than a fix, but zizmor flagged it and it is cheap.

## Unchanged

The `safe-to-deploy` gate and its `if:` expression, the branch-name prefix check for external PRs, the `comment-external-pr` job, every `NEXT_PUBLIC_*` build variable, `NODE_OPTIONS`, the `chmod +rX` step, the S3 destination, the CloudFront invalidation, and the preview URL comment. Same inputs, same output, same preview URL.

The build still receives the `NEXT_PUBLIC_*` values, which is unavoidable — they have to be baked into the bundle — and they are client-side values that ship in the built site anyway.

`destroy-preview-env.yaml` was checked and left alone: it holds `id-token: write` but never checks out or runs PR code, and it already passes `head.ref` through `env:` and sanitises it. Nothing to fix there.

## Verification

- `zizmor` — no findings (previously one `template-injection`).
- `actionlint` — 3 `info`-level shellcheck notes, identical count before and after; all pre-existing, none in the changed lines.
- Job permissions parsed back from the YAML to confirm the property holds: `build` has `{contents: read}` and checks out `head.sha`; `deploy` has `{id-token: write, pull-requests: write}` and does not.
- `actions/upload-artifact@v7.0.1` and `actions/download-artifact@v8.0.1` are pinned by full SHA and both build on `@actions/artifact` `^6.2.x`, so they interoperate.

## Note on the AWS side

This repo's `AWS_ACC_ROLE` currently points at a role shared with six other repositories. Narrowing that is vechain/vechain-kit-infra#27 — but that change cannot fix this workflow, because a preview deploy legitimately runs from a pull request and so legitimately presents the `pull_request` subject claim. The two changes are complementary: #27 limits what the role can reach, this PR keeps pull request code away from the credential.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved preview deployment workflow reliability by separating site building from publishing.
  * Preview builds now generate a dedicated artifact and transfer it to the deployment step.
  * Improved safety for builds from external contributions by tightening build-time credential handling.
  * Updated preview deployment messaging to reference the correct generated preview URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->