### PR TITLE
fix(generic-delegator): unblock first send from undeployed smart accounts

### DIFF
--- a/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts
+++ b/packages/vechain-kit/src/hooks/generic-delegator/useGenericDelegator.ts
@@ -105,7 +105,19 @@ export const delegateAuthorized = async (encodedSignedTx: string, origin: string
             token: token.toLowerCase(),
         }),
     });
-    const data = await response.json();
+    const data = await response.json().catch(() => null);
+    // Surface delegator rejections instead of returning the error body: a
+    // non-OK response has no `signature`, and letting it flow onwards used
+    // to crash later in signVip191Transaction ("Cannot read properties of
+    // undefined (reading 'slice')"), masking the real reason the delegator
+    // refused to sign.
+    if (!response.ok || typeof data?.signature !== 'string') {
+        throw new Error(
+            `Generic delegator rejected the transaction (HTTP ${
+                response.status
+            }): ${data?.message ?? JSON.stringify(data)}`,
+        );
+    }
     return data;
 }
 
@@ -286,7 +298,18 @@ export const computeCorrectedGasTokenCost = async ({
         gasToken,
         estimationResponse,
     });
-    return cost > 0 ? cost : fallbackCost;
+    // Never pay less than the delegator's own end-to-end estimate: for a
+    // not-yet-deployed smart account the final tx carries an extra
+    // createAccount clause (~200k gas) that the local recompute above does
+    // not model, so the local number can come out at roughly half of what
+    // the delegator's validation demands — which then rejects the tx
+    // ("Transfer not received" -> HTTP 500), hard-blocking every FIRST
+    // transaction of a fresh smart account. The delegator's /estimate
+    // response already prices the deploy clause, so clamp to it. Once the
+    // account is deployed the two estimates converge and this clamp is
+    // inert.
+    const clampedCost = Math.max(cost, estimationResponse.transactionCost ?? 0);
+    return clampedCost > 0 ? clampedCost : fallbackCost;
 };
 
 /**


### PR DESCRIPTION
## Problem

Every **first** transaction from a not-yet-deployed smart account (a fresh Privy/social-login user) fails with the catch-all error *"Failed to send transaction using generic delegator, no gas tokens have sufficient balance or are enabled in Gas Token Preferences"* — even with a fully funded wallet. Since a smart account only gets deployed by its first transaction, this is a chicken-and-egg that hard-blocks new social-login users from ever transacting.

Live-reproduced on testnet (kit 2.12.0, fresh smart account with 100 VET / `hasCode: false`, sending 1 VET):

1. `POST /api/v1/estimate/clauses/vet?type=smartaccount&speed=medium` → `estimatedGas: 358364`, `transactionCost: 0.316` VET (the delegator's estimate **includes** the `createAccount` deploy clause it knows the tx will need)
2. The kit's local recompute (`computeCorrectedGasTokenCost`) prices only the user clauses + wrapper overhead — it never models the deploy clause (~200k gas) — and builds a fee-transfer clause of **0.155 VET**
3. `POST /api/v1/sign/transaction/authorized/vet` → **HTTP 500** `{"message":"Error delegating tx"}` (server-side validation: transfer amount below expected cost → `Transfer not received`)
4. `delegateAuthorized` returns the error body without checking `response.ok`, so `signVip191Transaction` crashes on `gasPayerSignature.slice(2)` → `TypeError: Cannot read properties of undefined (reading 'slice')` → the misleading catch-all above

## Fix

- **`computeCorrectedGasTokenCost`**: clamp the final fee to at least the delegator's own `/estimate` `transactionCost`, which already prices the deploy clause. Once the account is deployed the two estimates converge, so the clamp is inert for every subsequent transaction — the local wrapper-aware recompute (#623) still wins whenever it is the higher, more accurate number.
- **`delegateAuthorized`**: throw with the delegator's real HTTP status + message on a non-OK / signature-less response instead of letting the error body flow into the signing step.

## Verification

With the fix applied (as a local patch on 2.12.0), the same testnet scenario succeeds end-to-end: the fee clause becomes 0.313 VET, the delegator signs, and on-chain the account goes 100 → 98.687 VET (1 sent + 0.313 fee), **VTHO untouched** (delegator paid the gas), smart account deployed in the same tx, recipient credited +1 VET.

`yarn kit:typecheck` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegated transaction error handling with clearer messages for failed responses or missing signatures.
  * Prevented invalid transaction data from propagating.
  * Improved gas cost calculations by respecting the delegator’s reported transaction cost when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->