### PR TITLE
chore(release): v2.12.1

### DIFF
--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {


### PR DESCRIPTION
Patch release preparing v2.12.1.

Includes #651 (generic-delegator first-send fix for undeployed smart accounts), already merged into `main`.

Version bump only — no new translatable strings, so `yarn translate` was not re-run for this release.

**Next steps once merged:** create the GitHub Release `2.12.1` on the merge commit (tags it automatically), which triggers `publish-vechain-kit.yaml` to publish to both npmjs.org and GitHub Packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `@vechain/vechain-kit` package to version 2.12.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->