### PR TITLE
feat(next-template): route production onramp through vechain/onramp-proxy

### DIFF
--- a/.github/workflows/deploy-cloudfront.yaml
+++ b/.github/workflows/deploy-cloudfront.yaml
@@ -29,7 +29,9 @@ jobs:
             NEXT_PUBLIC_PRIVY_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_CLIENT_ID }}
             NEXT_PUBLIC_DELEGATOR_URL: ${{ secrets.NEXT_PUBLIC_DELEGATOR_URL }}
             NEXT_PUBLIC_TRANSAK_API_KEY: ${{ secrets.NEXT_PUBLIC_TRANSAK_API_KEY_PROD }}
-            NEXT_PUBLIC_TRANSAK_API_URL: ${{ secrets.NEXT_PUBLIC_TRANSAK_API_URL }}
+            # Production talks to vechain/onramp-proxy; the preview deploy
+            # keeps NEXT_PUBLIC_TRANSAK_API_URL (vechain-kit-infra proxy).
+            NEXT_PUBLIC_TRANSAK_API_URL: ${{ secrets.NEXT_PUBLIC_TRANSAK_API_URL_PROD }}
             NEXT_PUBLIC_TRANSAK_ENVIRONMENT: 'production'
             NEXT_PUBLIC_NETWORK_TYPE: 'main'
             AWS_REGION: eu-west-1

--- a/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
+++ b/examples/next-template/src/app/providers/VechainKitProviderWrapper.tsx
@@ -134,6 +134,44 @@ export function VechainKitProviderWrapper({ children }: Props) {
                           }) => {
                               const apiUrl =
                                   process.env.NEXT_PUBLIC_TRANSAK_API_URL ?? '';
+                              const environment = process.env
+                                  .NEXT_PUBLIC_TRANSAK_ENVIRONMENT as
+                                  | 'staging'
+                                  | 'production'
+                                  | undefined;
+
+                              // Production goes through vechain/onramp-proxy
+                              // (the shared VeChain onramp backend, GET
+                              // contract). Staging keeps the vechain-kit-infra
+                              // proxy: onramp-proxy is production-only.
+                              if (environment === 'production') {
+                                  const params = new URLSearchParams({
+                                      provider: 'transak',
+                                      address: walletAddress,
+                                      os: 'web',
+                                      theme: 'LIGHT',
+                                      currency: fiatCurrency,
+                                      referrerDomain:
+                                          typeof window !== 'undefined'
+                                              ? window.location.origin
+                                              : '',
+                                  });
+                                  if (fiatAmount) {
+                                      params.set('fiatAmount', fiatAmount);
+                                  }
+                                  const res = await fetch(
+                                      `${apiUrl}/?${params.toString()}`,
+                                  );
+                                  const json = await res.json();
+                                  if (!res.ok || !json?.url) {
+                                      throw new Error(
+                                          json?.error ??
+                                              'Failed to create Transak widget URL',
+                                      );
+                                  }
+                                  return json.url as string;
+                              }
+
                               const res = await fetch(
                                   `${apiUrl}/api/transak/widget-url`,
                                   {


### PR DESCRIPTION
Converges the production fiat onramp on `vechain/onramp-proxy` (shared VeChain backend, see vechain/onramp-proxy#29) while the preview env keeps the current vechain-kit-infra proxy.

## Changes

- `widgetUrlBuilder` in the example wrapper branches on `NEXT_PUBLIC_TRANSAK_ENVIRONMENT`:
  - `production` → `GET {API_URL}/?provider=transak&address=…&os=web&theme=LIGHT&currency=…&referrerDomain=…&fiatAmount=…` → `{url}` (onramp-proxy contract)
  - `staging` (preview) → existing POST contract, unchanged
- `deploy-cloudfront.yaml` reads the URL from a new secret `NEXT_PUBLIC_TRANSAK_API_URL_PROD` (→ `https://onramp-proxy.vechain.org`); `deploy-preview.yaml` untouched.

## Requires

- vechain/onramp-proxy#29 merged and deployed (multi-origin CORS + parametric referrerDomain)
- repo secret `NEXT_PUBLIC_TRANSAK_API_URL_PROD`
- kit-site / marketplace domains allow-listed as referrerDomain on the Transak production dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production-specific Transak widget URL handling.
  * Production requests now use a GET-based flow with improved error reporting.
* **Bug Fixes**
  * Production deployments now use the correct Transak API endpoint configuration.
  * Non-production environments continue using the existing widget creation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->