### PR TITLE
chore(release): v2.13.0

### DIFF
--- a/packages/vechain-kit/package.json
+++ b/packages/vechain-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/vechain-kit",
-    "version": "2.12.1",
+    "version": "2.13.0",
     "author": "VeChain Foundation",
     "homepage": "https://github.com/vechain/vechain-kit",
     "repository": {


### PR DESCRIPTION
## Summary
Minor release preparing **v2.13.0**.

Includes everything already on `main` since 2.12.1:
- SDK **2.1.0** / dapp-kit **2.3.3** (Interstellar / EIP-7825) — #658
- Transak fiat onramp (native VET) — #649, #654, #655, #656
- Preview deploy CI split — #648

Version bump only. Locale files are already in sync (527 keys × 16 languages), so `yarn translate` was not re-run (no `OPENAI_API_KEY` in this environment).

## Next steps once merged
1. Create the GitHub Release `2.13.0` on the merge commit (tags it automatically).
2. That tag triggers `publish-vechain-kit.yaml` to publish to npmjs.org and GitHub Packages.

## Test plan
- [x] Version is `2.13.0` in `packages/vechain-kit/package.json`
- [ ] After merge: GitHub Release `2.13.0` created
- [ ] Confirm `@vechain/vechain-kit@2.13.0` on npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `@vechain/vechain-kit` package to version 2.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->